### PR TITLE
Fixes refined types applies:

### DIFF
--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -17,6 +17,7 @@
 package com.fortyseven.common.configuration
 
 import scala.compiletime.ops.string.Matches
+import scala.compiletime.ops.int.*
 import scala.compiletime.{codeOf, constValue, error}
 import scala.util.Try
 
@@ -210,9 +211,9 @@ object refinedTypes:
      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(int: Int): PositiveInt =
-      inline if int < 0
-      then error(codeOf(int) + " is negative. Int must be positive.")
-      else int
+      inline if constValue[>[int.type, 0]]
+      then int
+      else error(codeOf(int) + " is negative. Int must be positive.")
 
     /**
      * When the compiler expects a value of type Int but it finds a value of type PositiveInt, it executes this.

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -16,8 +16,8 @@
 
 package com.fortyseven.common.configuration
 
-import scala.compiletime.ops.string.Matches
 import scala.compiletime.ops.int.*
+import scala.compiletime.ops.string.Matches
 import scala.compiletime.{codeOf, constValue, error}
 import scala.util.Try
 

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -211,7 +211,7 @@ object refinedTypes:
      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(int: Int): PositiveInt =
-      inline if constValue[>[int.type, 0]]
+      inline if constValue[int.type >= 0]
       then int
       else error(codeOf(int) + " is negative. Int must be positive.")
 

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
@@ -31,7 +31,7 @@ class FlinkProcessorConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F,
     for
       kafkaBrokerAddress                 <- default("localhost:9092").as[NonEmptyString]
       kafkaConsumerTopicName             <- default("input-topic-pp").as[NonEmptyString]
-      kafkaConsumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.Earliest).as[KafkaAutoOffsetReset]
+      kafkaConsumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
       kafkaConsumerGroupId               <- default("groupId").as[NonEmptyString]
       kafkaConsumerMaxConcurrent         <- default(25).as[PositiveInt]
       kafkaProducerTopicName             <- default("output-topic").as[NonEmptyString]

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
@@ -31,7 +31,7 @@ final class KafkaConsumerConfigurationLoader[F[_]: Async] extends ConfigurationA
     for
       brokerAddress                 <- default("localhost:9092").as[NonEmptyString]
       consumerTopicName             <- default("data-generator").as[NonEmptyString]
-      consumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.Earliest).as[KafkaAutoOffsetReset]
+      consumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
       consumerGroupId               <- default("groupId").as[NonEmptyString]
       consumerMaxConcurrent         <- default(25).as[PositiveInt]
       producerTopicName             <- default("input-topic").as[NonEmptyString]

--- a/04-i-consumer-kafka/src/main/scala/com/fortyseven/kafkaconsumer/KafkaConsumer.scala
+++ b/04-i-consumer-kafka/src/main/scala/com/fortyseven/kafkaconsumer/KafkaConsumer.scala
@@ -32,9 +32,9 @@ final class KafkaConsumer[F[_]: Async] extends KafkaConsumerAPI[F]:
 
   given Conversion[KafkaAutoOffsetReset, AutoOffsetReset] with
     def apply(x: KafkaAutoOffsetReset): AutoOffsetReset = x match
-      case KafkaAutoOffsetReset.Earliest => AutoOffsetReset.Earliest
-      case KafkaAutoOffsetReset.Latest   => AutoOffsetReset.Latest
-      case KafkaAutoOffsetReset.None     => AutoOffsetReset.None
+      case KafkaAutoOffsetReset.earliest => AutoOffsetReset.Earliest
+      case KafkaAutoOffsetReset.latest   => AutoOffsetReset.Latest
+      case KafkaAutoOffsetReset.none     => AutoOffsetReset.None
 
   override def consume[Configuration <: KafkaConsumerConfigurationI](config: Configuration): F[Unit] = runWithConfiguration(config)
 


### PR DESCRIPTION
The apply methods of the refined types were broken since the bodies could not be inlined during "execution" time (in the console). 

- Removes the requireConstant method in the body of the applies since the body is also inlined.
- inline match for enums
- constValue[T] for refined primitives (String)