### PR TITLE
Fix/configuration refine types

### DIFF
--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/ids/IdsCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/ids/IdsCodecs.scala
@@ -24,8 +24,8 @@ import vulcan.Codec
  */
 object IdsCodecs:
 
-  given bicycleIdCodec: Codec[BicycleId] = Codec.uuid.imap(BicycleId.apply)(_.value)
+  given bicycleIdCodec: Codec[BicycleId] = Codec.uuid.imap(BicycleId.apply)(identity)
 
-  given userIdCodec: Codec[UserId] = Codec.uuid.imap(UserId.apply)(_.value)
+  given userIdCodec: Codec[UserId] = Codec.uuid.imap(UserId.apply)(identity)
 
-  given tripIdCodec: Codec[TripId] = Codec.uuid.imap(TripId.apply)(_.value)
+  given tripIdCodec: Codec[TripId] = Codec.uuid.imap(TripId.apply)(identity)

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/types/TypesCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/types/TypesCodecs.scala
@@ -27,20 +27,20 @@ import vulcan.{AvroError, Codec}
 object TypesCodecs:
 
   given latitudeCodec: Codec[Latitude] =
-    Codec.double.imapError(Latitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+    Codec.double.imapError(Latitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(identity)
 
   given longitudeCodec: Codec[Longitude] =
-    Codec.double.imapError(Longitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+    Codec.double.imapError(Longitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(identity)
 
   given percentageCodec: Codec[Percentage] =
-    Codec.double.imapError(Percentage.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+    Codec.double.imapError(Percentage.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(identity)
 
   given speedCodec: Codec[Speed] =
-    Codec.double.imapError(Speed.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+    Codec.double.imapError(Speed.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(identity)
 
-  given hertzCodec: Codec[Hz] = Codec.double.imapError(Hz.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given hertzCodec: Codec[Hz] = Codec.double.imapError(Hz.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(identity)
 
-  given barCodec: Codec[Bar] = Codec.double.imapError(Bar.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given barCodec: Codec[Bar] = Codec.double.imapError(Bar.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(identity)
 
   given metersCodec: Codec[Meters] =
-    Codec.int.imapError(Meters.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+    Codec.int.imapError(Meters.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(identity)

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/ids.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/ids.scala
@@ -44,16 +44,8 @@ object ids:
      */
     def apply(id: UUID): BicycleId = id
 
-    extension (bicycleId: BicycleId)
-      /**
-       * Exposes the bicycle ID as the underlying UUID type.
-       *
-       * @return
-       *   an UUID.
-       * @see
-       *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
-       */
-      def value: UUID = bicycleId
+    given Conversion[BicycleId, UUID] with
+      override def apply(x: BicycleId): UUID = x
 
   /**
    * Factory for [[UserId]] instances.
@@ -70,16 +62,8 @@ object ids:
      */
     def apply(id: UUID): UserId = id
 
-    extension (userId: UserId)
-      /**
-       * Exposes the user ID as the underlying UUID type.
-       *
-       * @return
-       *   un UUID.
-       * @see
-       *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
-       */
-      def value: UUID = userId
+    given Conversion[UserId, UUID] with
+      override def apply(x: UserId): UUID = x
 
   /**
    * Factory for [[TripId]] instances.
@@ -96,13 +80,5 @@ object ids:
      */
     def apply(tripID: UUID): TripId = tripID
 
-    extension (tripId: TripId)
-      /**
-       * Exposes the trip ID as the underlying UUID type.
-       *
-       * @return
-       *   an UUID.
-       * @see
-       *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
-       */
-      def value: UUID = tripId
+    given Conversion[TripId, UUID] with
+      override def apply(x: TripId): UUID = x

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/refinedTypes.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/refinedTypes.scala
@@ -16,7 +16,7 @@
 
 package com.fortyseven.domain.model.types
 
-import scala.compiletime.{error, requireConst}
+import scala.compiletime.{codeOf, error}
 
 import com.fortyseven.domain.model.iot.errors.*
 
@@ -55,6 +55,8 @@ object refinedTypes:
    */
   object Latitude:
 
+    inline val errorMessage = " invalid latitude value. Accepted coordinate values are between -90.0 and 90.0."
+
     /**
      * Smart constructor for unknown doubles at compile time.
      *
@@ -63,9 +65,10 @@ object refinedTypes:
      * @return
      *   An Either with a Right Latitude or a Left OutOfBoundsError.
      */
-    def from(coordinateCandidate: Double): Either[OutOfBoundsError, Latitude] = coordinateCandidate match
-      case c if c < -90.0 || c > 90.0 => Left(OutOfBoundsError(s"Invalid latitude value $c"))
-      case c                          => Right(c)
+    def from(coordinateCandidate: Double): Either[OutOfBoundsError, Latitude] =
+      if coordinateCandidate < -90.0 || coordinateCandidate > 90.0
+      then Left(OutOfBoundsError(coordinateCandidate.toString + errorMessage))
+      else Right(coordinateCandidate)
 
     /**
      * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -78,17 +81,19 @@ object refinedTypes:
      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(coordinate: Double): Latitude =
-      requireConst(coordinate)
       inline if coordinate < -90.0 || coordinate > 90.0
-      then error("Invalid latitude value. Accepted coordinate values are between -90.0 and 90.0.")
+      then error(codeOf(coordinate) + errorMessage)
       else coordinate
 
-    extension (coordinate: Latitude) def value: Double = coordinate
+    given Conversion[Latitude, Double] with
+      override def apply(x: Latitude): Double = x
 
   /**
    * Factory for [[Longitude]] instances.
    */
   object Longitude:
+
+    inline val errorMessage = " invalid longitude value. Accepted coordinate values are between -180.0 and 180.0."
 
     /**
      * Smart constructor for unknown doubles at compile time.
@@ -98,9 +103,10 @@ object refinedTypes:
      * @return
      *   An Either with a Right Longitude or a Left OutOfBoundsError.
      */
-    def from(coordinateCandidate: Double): Either[OutOfBoundsError, Longitude] = coordinateCandidate match
-      case c if c < -180.0 || c > 180.0 => Left(OutOfBoundsError(s"Invalid longitude value $c"))
-      case c                            => Right(c)
+    def from(coordinateCandidate: Double): Either[OutOfBoundsError, Longitude] =
+      if coordinateCandidate < -180.0 || coordinateCandidate > 180.0
+      then Left(OutOfBoundsError(coordinateCandidate.toString + errorMessage))
+      else Right(coordinateCandidate)
 
     /**
      * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -113,17 +119,19 @@ object refinedTypes:
      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(coordinate: Double): Longitude =
-      requireConst(coordinate)
       inline if coordinate < -180.0 || coordinate > 180.0
-      then error("Invalid longitude value. Accepted coordinate values are between -180.0 and 180.0.")
+      then error(codeOf(coordinate) + errorMessage)
       else coordinate
 
-    extension (coordinate: Longitude) def value: Double = coordinate
+    given Conversion[Longitude, Double] with
+      override def apply(x: Longitude): Double = x
 
   /**
    * Factory for [[Percentage]] instances.
    */
   object Percentage:
+
+    inline val errorMessage = " invalid percentage value. Accepted percentage values are between -0.0 and 100.0."
 
     /**
      * Smart constructor for unknown doubles at compile time.
@@ -133,9 +141,10 @@ object refinedTypes:
      * @return
      *   An Either with a Right Percentage or a Left OutOfBoundsError.
      */
-    def from(percentageCandidate: Double): Either[OutOfBoundsError, Percentage] = percentageCandidate match
-      case p if p < 0.0 || p > 100.0 => Left(OutOfBoundsError(s"Invalid percentage value $p"))
-      case percentage                => Right(percentage)
+    def from(percentageCandidate: Double): Either[OutOfBoundsError, Percentage] =
+      if percentageCandidate < 0.0 || percentageCandidate > 100.0
+      then Left(OutOfBoundsError(percentageCandidate.toString + errorMessage))
+      else Right(percentageCandidate)
 
     /**
      * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -148,17 +157,19 @@ object refinedTypes:
      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(percentage: Double): Percentage =
-      requireConst(percentage)
       inline if percentage < 0.0 || percentage > 100.0
-      then error("Invalid percentage value. Accepted percentage values are between -0.0 and 100.0.")
+      then error(codeOf(percentage) + errorMessage)
       else percentage
 
-    extension (percentage: Percentage) def value: Double = percentage
+  given Conversion[Percentage, Double] with
+    override def apply(x: Percentage): Double = x
 
   /**
    * Factory for [[Speed]] instances.
    */
   object Speed:
+
+    inline val errorMessage = " invalid speed value. Accepted speed values are greater than 0.0."
 
     /**
      * Smart constructor for unknown doubles at compile time.
@@ -168,9 +179,10 @@ object refinedTypes:
      * @return
      *   An Either with a Right Speed or a Left OutOfBoundsError.
      */
-    def from(speedCandidate: Double): Either[OutOfBoundsError, Speed] = speedCandidate match
-      case speed if speed < 0.0 => Left(OutOfBoundsError(s"Invalid speed value $speed"))
-      case speed                => Right(speed)
+    def from(speedCandidate: Double): Either[OutOfBoundsError, Speed] =
+      if speedCandidate < 0.0
+      then Left(OutOfBoundsError(speedCandidate.toString + errorMessage))
+      else Right(speedCandidate)
 
     /**
      * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -183,17 +195,19 @@ object refinedTypes:
      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(speed: Double): Speed =
-      requireConst(speed)
       inline if speed < 0.0
-      then error("Invalid speed value. Accepted speed values are greater than 0.0.")
+      then error(codeOf(speed) + errorMessage)
       else speed
 
-    extension (speed: Speed) def value: Double = speed
+    given Conversion[Speed, Double] with
+      override def apply(x: Speed): Double = x
 
   /**
    * Factory for [[Hz]] instances.
    */
   object Hz:
+
+    inline val errorMessage = " invalid frequency value. Accepted hertz values are greater than 0.0."
 
     /**
      * Smart constructor for unknown doubles at compile time.
@@ -203,9 +217,10 @@ object refinedTypes:
      * @return
      *   An Either with a Right Hz or a Left OutOfBoundsError.
      */
-    def from(hertzCandidate: Double): Either[OutOfBoundsError, Hz] = hertzCandidate match
-      case hz if hz < 0.0 => Left(OutOfBoundsError(s"Invalid frequency value $hz"))
-      case hz             => Right(hz)
+    def from(hertzCandidate: Double): Either[OutOfBoundsError, Hz] =
+      if hertzCandidate < 0.0
+      then Left(OutOfBoundsError(hertzCandidate.toString + errorMessage))
+      else Right(hertzCandidate)
 
     /**
      * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -219,15 +234,18 @@ object refinedTypes:
      */
     inline def apply(hertz: Double): Hz =
       inline if hertz < 0.0
-      then error("Invalid frequency value. Accepted hertz values are greater than 0.0.")
+      then error(codeOf(hertz) + errorMessage)
       else hertz
 
-    extension (hertz: Hz) def value: Double = hertz
+    given Conversion[Hz, Double] with
+      override def apply(x: Hz): Double = x
 
   /**
    * Factory for [[Bar]] instances.
    */
   object Bar:
+
+    inline val errorMessage = " invalid pressure value. Accepted bar values are greater than 0.0."
 
     /**
      * Smart constructor for unknown doubles at compile time.
@@ -237,9 +255,10 @@ object refinedTypes:
      * @return
      *   An Either with a Right Bar or a Left OutOfBoundsError.
      */
-    def from(barCandidate: Double): Either[OutOfBoundsError, Bar] = barCandidate match
-      case p if p < 0.0 => Left(OutOfBoundsError(s"Invalid pressure value $p"))
-      case p            => Right(p)
+    def from(barCandidate: Double): Either[OutOfBoundsError, Bar] =
+      if barCandidate < 0.0
+      then Left(OutOfBoundsError(barCandidate.toString + errorMessage))
+      else Right(barCandidate)
 
     /**
      * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -252,17 +271,19 @@ object refinedTypes:
      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(bar: Double): Bar =
-      requireConst(bar)
       inline if bar < 0.0
-      then error("Invalid pressure value. Accepted bar values are greater than 0.0.")
+      then error(codeOf(bar) + errorMessage)
       else bar
 
-    extension (bar: Bar) def value: Double = bar
+  given Conversion[Bar, Double] with
+    override def apply(x: Bar): Double = x
 
   /**
    * Factory for [[Meters]] instances.
    */
   object Meters:
+
+    inline val errorMessage = " invalid meters value. Accepted bar values are greater than 0."
 
     /**
      * Smart constructor for unknown integers at compile time.
@@ -272,9 +293,10 @@ object refinedTypes:
      * @return
      *   An Either with a Right Meters or a Left OutOfBoundsError.
      */
-    def from(metersCandidate: Int): Either[OutOfBoundsError, Meters] = metersCandidate match
-      case meters if meters < 0 => Left(OutOfBoundsError(s"Invalid meters value $meters"))
-      case meters               => Right(meters)
+    def from(metersCandidate: Int): Either[OutOfBoundsError, Meters] =
+      if metersCandidate < 0
+      then Left(OutOfBoundsError(metersCandidate.toString + errorMessage))
+      else Right(metersCandidate)
 
     /**
      * Smart constructor for known integers at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -287,9 +309,9 @@ object refinedTypes:
      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(meters: Int): Meters =
-      requireConst(meters)
       inline if meters < 0
-      then error("Invalid meters value. Accepted bar values are greater than 0.")
+      then error(codeOf(meters) + errorMessage)
       else meters
 
-    extension (meters: Meters) def value: Int = meters
+    given Conversion[Meters, Int] with
+      override def apply(x: Meters): Int = x

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/idsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/idsTest.scala
@@ -29,12 +29,12 @@ class idsTest extends ScalaCheckSuite:
 
   property("BicycleId should build from a valid UUID and method call value should return the same UUID"):
     forAll: (uuid: UUID) =>
-      assertEquals(BicycleId(uuid).value, uuid)
+      uuid == BicycleId(uuid)
 
   property("UserId should build from a valid UUID and method call value should return the same UUID"):
     forAll: (uuid: UUID) =>
-      assertEquals(UserId(uuid).value, uuid)
+      uuid == UserId(uuid)
 
   property("TripId should build from a valid UUID and method call value should return the same UUID"):
     forAll: (uuid: UUID) =>
-      assertEquals(TripId(uuid).value, uuid)
+      uuid == TripId(uuid)

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/refinedTypesTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/refinedTypesTest.scala
@@ -16,6 +16,8 @@
 
 package com.fortyseven.domain.model.types
 
+import scala.compiletime.testing.{typeCheckErrors, typeChecks}
+
 import com.fortyseven.domain.model.types.refinedTypes.*
 import munit.ScalaCheckSuite
 import org.scalacheck
@@ -32,9 +34,22 @@ class refinedTypesTest extends ScalaCheckSuite:
     forAll(Gen.chooseNum(Double.MinValue, -90.0).suchThat(_ < -90.0)): latitude =>
       Latitude.from(latitude).isLeft
 
+  test("Invalid Latitude value should raise a compiler error"):
+    assertNoDiff(
+      typeCheckErrors("Latitude.apply(91.0)").head.message,
+      s"91.0d${Latitude.errorMessage}"
+    )
+    assertNoDiff(
+      typeCheckErrors("Latitude.apply(-91.0)").head.message,
+      s"-91.0d${Latitude.errorMessage}"
+    )
+
   property("Latitude should build from values that conform with Earth latitude limits"):
     forAll(Gen.chooseNum(-90.0, 90.0)): latitude =>
       Latitude.from(latitude).isRight
+
+  test("Valid Latitude value should compile"):
+    assert(typeChecks("Latitude.apply(0.0)"))
 
   property("Longitude grater than 180 are not allowed"):
     forAll(Gen.chooseNum(180.0, Double.MaxValue).suchThat(_ > 180.0)): longitude =>
@@ -44,9 +59,22 @@ class refinedTypesTest extends ScalaCheckSuite:
     forAll(Gen.chooseNum(Double.MinValue, -180.0).suchThat(_ < -180.0)): longitude =>
       Longitude.from(longitude).isLeft
 
+  test("Invalid Longitude value should raise a compiler error"):
+    assertNoDiff(
+      typeCheckErrors("Longitude.apply(181.0)").head.message,
+      s"181.0d${Longitude.errorMessage}"
+    )
+    assertNoDiff(
+      typeCheckErrors("Longitude.apply(-181.0)").head.message,
+      s"-181.0d${Longitude.errorMessage}"
+    )
+
   property("Longitude should build from values that conform with Earth longitude limits"):
     forAll(Gen.chooseNum(-180.0, 180.0)): longitude =>
       Longitude.from(longitude).isRight
+
+  test("Valid Longitude value should compile"):
+    assert(typeChecks("Longitude.apply(0.0)"))
 
   property("An invalid Percentage should have values bellow 0"):
     forAll(Gen.negNum[Double]): percentage =>
@@ -56,38 +84,87 @@ class refinedTypesTest extends ScalaCheckSuite:
     forAll(Gen.chooseNum(100.0, Double.MaxValue).suchThat(_ > 100.0)): percentage =>
       Percentage.from(percentage).isLeft
 
+  test("Invalid Percentage value should raise a compiler error"):
+    assertNoDiff(
+      typeCheckErrors("Percentage.apply(101.0)").head.message,
+      s"101.0d${Percentage.errorMessage}"
+    )
+    assertNoDiff(
+      typeCheckErrors("Percentage.apply(-1.0)").head.message,
+      s"-1.0d${Percentage.errorMessage}"
+    )
+
   property("A valid Percentage should have values between 0 and 100"):
     forAll(Gen.chooseNum(0.0, 100.0)): percentage =>
       Percentage.from(percentage).isRight
+
+  test("Valid Percentage value should compile"):
+    assert(typeChecks("Percentage.apply(0.0)"))
 
   property("An invalid Speed should have a value lower than 0"):
     forAll(Gen.negNum[Double]): speed =>
       Speed.from(speed).isLeft
 
+  test("Invalid Speed value should raise a compiler error"):
+    assertNoDiff(
+      typeCheckErrors("Speed.apply(-1.0)").head.message,
+      s"-1.0d${Speed.errorMessage}"
+    )
+
   property("A valid Speed should have a value equal to 0 or higher"):
     forAll(Gen.posNum[Double]): speed =>
       Speed.from(speed).isRight
+
+  test("Valid Speed value should compile"):
+    assert(typeChecks("Speed.apply(0.0)"))
 
   property("An invalid Hz should have a value lower than 0"):
     forAll(Gen.negNum[Double]): hz =>
       Hz.from(hz).isLeft
 
+  test("Invalid Hz value should raise a compiler error"):
+    assertNoDiff(
+      typeCheckErrors("Hz.apply(-1.0)").head.message,
+      s"-1.0d${Hz.errorMessage}"
+    )
+
   property("A valid Hz should have a value equal to 0 or higher"):
     forAll(Gen.posNum[Double]): hz =>
       Hz.from(hz).isRight
+
+  test("Valid Hz value should compile"):
+    assert(typeChecks("Hz.apply(0.0)"))
 
   property("An invalid Bar should have a value lower than 0"):
     forAll(Gen.negNum[Double]): bar =>
       Bar.from(bar).isLeft
 
+  test("Invalid Bar value should raise a compiler error"):
+    assertNoDiff(
+      typeCheckErrors("Bar.apply(-1.0)").head.message,
+      s"-1.0d${Bar.errorMessage}"
+    )
+
   property("A valid Bar should have a value equal to 0 or higher"):
     forAll(Gen.posNum[Double]): bar =>
       Bar.from(bar).isRight
+
+  test("Valid Bar value should compile"):
+    assert(typeChecks("Bar.apply(0.0)"))
 
   property("An invalid Meters should have a value lower than 0"):
     forAll(Gen.negNum[Int]): meters =>
       Meters.from(meters).isLeft
 
+  test("Invalid Meters value should raise a compiler error"):
+    assertNoDiff(
+      typeCheckErrors("Meters.apply(-1)").head.message,
+      s"-1${Meters.errorMessage}"
+    )
+
   property("A valid Meters should have a value equal to 0 or higher"):
     forAll(Gen.posNum[Int]): meters =>
       Meters.from(meters).isRight
+
+  test("Valid Meters value should compile"):
+    assert(typeChecks("Meters.apply(0)"))

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -17,6 +17,7 @@
 package com.fortyseven.common.configuration
 
 import scala.compiletime.ops.string.Matches
+import scala.compiletime.ops.int.*
 import scala.compiletime.{codeOf, constValue, error}
 import scala.util.Try
 
@@ -210,9 +211,9 @@ object refinedTypes:
      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(int: Int): PositiveInt =
-      inline if int < 0
-      then error(codeOf(int) + " is negative. Int must be positive.")
-      else int
+      inline if constValue[>[int.type, 0]]
+      then int
+      else error(codeOf(int) + " is negative. Int must be positive.")
 
     /**
      * When the compiler expects a value of type Int but it finds a value of type PositiveInt, it executes this.

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -16,8 +16,8 @@
 
 package com.fortyseven.common.configuration
 
-import scala.compiletime.ops.string.Matches
 import scala.compiletime.ops.int.*
+import scala.compiletime.ops.string.Matches
 import scala.compiletime.{codeOf, constValue, error}
 import scala.util.Try
 

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -211,7 +211,7 @@ object refinedTypes:
      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(int: Int): PositiveInt =
-      inline if constValue[>[int.type, 0]]
+      inline if constValue[int.type >= 0]
       then int
       else error(codeOf(int) + " is negative. Int must be positive.")
 

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -140,6 +140,8 @@ object refinedTypes:
    */
   object NonEmptyString:
 
+    private inline val validation = "^\\S+$"
+
     /**
      * Smart constructor for unknown strings at compile time.
      *
@@ -149,9 +151,9 @@ object refinedTypes:
      *   An Either with a Right NonEmptyString or a Left IllegalStateException.
      */
     def from(nonEmptyStringCandidate: String): Either[Throwable, NonEmptyString] =
-      if nonEmptyStringCandidate.isBlank
-      then Left(new IllegalStateException(s"The provided string $nonEmptyStringCandidate is empty."))
-      else Right(nonEmptyStringCandidate)
+      if validation.r.matches(nonEmptyStringCandidate)
+      then Right(nonEmptyStringCandidate)
+      else Left(new IllegalStateException(s"The provided string $nonEmptyStringCandidate is empty."))
 
     /**
      * Smart constructor for known strings at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
@@ -164,7 +166,7 @@ object refinedTypes:
      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
      */
     inline def apply(nonEmptyString: String): NonEmptyString =
-      inline if constValue[Matches[nonEmptyString.type, "^\\S+$"]]
+      inline if constValue[Matches[nonEmptyString.type, validation.type]]
       then nonEmptyString
       else error(codeOf(nonEmptyString) + " is invalid. Empty String is not allowed here.")
 
@@ -196,9 +198,9 @@ object refinedTypes:
      *   An Either with a Right PositiveInt or a Left IllegalStateException.
      */
     def from(intCandidate: Int): Either[Throwable, PositiveInt] =
-      if intCandidate < 0
-      then Left(new IllegalStateException(s"The provided int $intCandidate is not positive."))
-      else Right(intCandidate)
+      if intCandidate >= 0
+      then Right(intCandidate)
+      else Left(new IllegalStateException(s"The provided int $intCandidate is not positive."))
 
     /**
      * Smart constructor for known integers at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
@@ -31,7 +31,7 @@ class FlinkProcessorConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F,
     for
       kafkaBrokerAddress                 <- default("localhost:9092").as[NonEmptyString]
       kafkaConsumerTopicName             <- default("input-topic-pp").as[NonEmptyString]
-      kafkaConsumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.Earliest).as[KafkaAutoOffsetReset]
+      kafkaConsumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
       kafkaConsumerGroupId               <- default("groupId").as[NonEmptyString]
       kafkaConsumerMaxConcurrent         <- default(25).as[PositiveInt]
       kafkaProducerTopicName             <- default("output-topic").as[NonEmptyString]

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
@@ -31,7 +31,7 @@ final class KafkaConsumerConfigurationLoader[F[_]: Async] extends ConfigurationA
     for
       brokerAddress                 <- default("localhost:9092").as[NonEmptyString]
       consumerTopicName             <- default("data-generator").as[NonEmptyString]
-      consumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.Earliest).as[KafkaAutoOffsetReset]
+      consumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
       consumerGroupId               <- default("groupId").as[NonEmptyString]
       consumerMaxConcurrent         <- default(25).as[PositiveInt]
       producerTopicName             <- default("input-topic").as[NonEmptyString]

--- a/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/ModelGenerators.scala
+++ b/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/ModelGenerators.scala
@@ -37,7 +37,7 @@ final class ModelGenerators[F[_]: Temporal](meteredInterval: FiniteDuration):
 
       (Latitude.from(getValue(latValue)), Longitude.from(getValue(lonValue))) match
         case (Right(lat), Right(lon)) =>
-          fs2.Stream.emit(GPSPosition(lat, lon)).metered(meteredInterval) ++ emitLoop(lat.value, lon.value)
+          fs2.Stream.emit(GPSPosition(lat, lon)).metered(meteredInterval) ++ emitLoop(lat, lon)
         case _ => emitLoop(latValue, lonValue)
 
     emitLoop(latValue = 2.0, lonValue = 2.0)
@@ -46,7 +46,7 @@ final class ModelGenerators[F[_]: Temporal](meteredInterval: FiniteDuration):
 
     def emitLoop(pValue: Double): fs2.Stream[F, PneumaticPressure] =
       Bar.from(pValue - math.random() * 1e-3) match
-        case Right(p) => fs2.Stream.emit(PneumaticPressure(p)).metered(meteredInterval) ++ emitLoop(p.value)
+        case Right(p) => fs2.Stream.emit(PneumaticPressure(p)).metered(meteredInterval) ++ emitLoop(p)
         case _        => emitLoop(pValue)
 
     emitLoop(pValue = 2.0)

--- a/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/DataGeneratorSuite.scala
+++ b/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/DataGeneratorSuite.scala
@@ -32,12 +32,12 @@ class DataGeneratorSuite extends CatsEffectSuite with ScalaCheckEffectSuite:
     PropF.forAllF(Gen.choose(1, 20)) { (sampleSize: Int) =>
       for
         sample <- dataGenerator.generateGPSPosition.take(sampleSize).compile.toList
-        _ = sample.foreach(it => assert(it.latitude.value >= -90.0 && it.latitude.value <= 90.0))
-        _ = sample.foreach(it => assert(it.longitude.value >= -180.0 && it.longitude.value <= 180.0))
+        _ = sample.foreach(it => assert(it.latitude >= -90.0 && it.latitude <= 90.0))
+        _ = sample.foreach(it => assert(it.longitude >= -180.0 && it.longitude <= 180.0))
         _ = sample
-              .sliding(2).map(l =>
-                (math.abs(l.head.latitude.value - l.last.latitude.value), math.abs(l.head.longitude.value - l.last.longitude.value))
-              ).foreach(it => assert(it._1 <= 1e-3 && it._2 <= 1e-3))
+              .sliding(2).map(l => (math.abs(l.head.latitude - l.last.latitude), math.abs(l.head.longitude - l.last.longitude))).foreach(it =>
+                assert(it._1 <= 1e-3 && it._2 <= 1e-3)
+              )
       yield ()
     }
 
@@ -45,7 +45,7 @@ class DataGeneratorSuite extends CatsEffectSuite with ScalaCheckEffectSuite:
     PropF.forAllF(Gen.choose(1, 20)) { (sampleSize: Int) =>
       for
         sample <- dataGenerator.generatePneumaticPressure.take(sampleSize).compile.toList
-        _ = sample.foreach(it => assert(it.pressure.value > 0.0))
-        _ = sample.sliding(2).map(l => l.head.pressure.value - l.last.pressure.value).foreach(it => assert(it >= 0 && it <= 1e-3))
+        _ = sample.foreach(it => assert(it.pressure > 0.0))
+        _ = sample.sliding(2).map(l => l.head.pressure - l.last.pressure).foreach(it => assert(it >= 0 && it <= 1e-3))
       yield ()
     }

--- a/04-i-consumer-kafka/src/main/scala/com/fortyseven/kafkaconsumer/KafkaConsumer.scala
+++ b/04-i-consumer-kafka/src/main/scala/com/fortyseven/kafkaconsumer/KafkaConsumer.scala
@@ -32,9 +32,9 @@ final class KafkaConsumer[F[_]: Async] extends KafkaConsumerAPI[F]:
 
   given Conversion[KafkaAutoOffsetReset, AutoOffsetReset] with
     def apply(x: KafkaAutoOffsetReset): AutoOffsetReset = x match
-      case KafkaAutoOffsetReset.Earliest => AutoOffsetReset.Earliest
-      case KafkaAutoOffsetReset.Latest   => AutoOffsetReset.Latest
-      case KafkaAutoOffsetReset.None     => AutoOffsetReset.None
+      case KafkaAutoOffsetReset.earliest => AutoOffsetReset.Earliest
+      case KafkaAutoOffsetReset.latest   => AutoOffsetReset.Latest
+      case KafkaAutoOffsetReset.none     => AutoOffsetReset.None
 
   override def consume[Configuration <: KafkaConsumerConfigurationI](config: Configuration): F[Unit] = runWithConfiguration(config)
 


### PR DESCRIPTION
This PR tries to unify the way the opaque types are validated by locating the validation for both methods `apply` and `from` in one place (in the case of strings) or to be identical in the case of Numeric types.

The usage of extension methods to access the underlying value of the opaque type has been replace by the usage of the Conversion[A, B] mechanics. Thus, the definition of the Vulcan Codecs resembles better the industry standards by providing as second parameter `identity`.