### PR TITLE
Update ScalaFix & Scalafmt

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,16 +1,29 @@
 rules = [
-    OrganizeImports
+  DisableSyntax,
+  LeakingImplicitClassVal,
+  NoAutoTupling,
+  NoValInForComprehension,
+  OrganizeImports,
+  RedundantSyntax
 ]
 
+DisableSyntax {
+  noReturns = true
+  noXml = true
+  noFinalVal = true
+}
+
 OrganizeImports {
+  blankLines = Auto
   expandRelative = true
-  groupedImports = Merge
+  importsOrder = SymbolsFirst
+  importSelectorsOrder = SymbolsFirst
   removeUnused = false
   groups = [
-    "re:(java?|scala)\\.",
-    "cats.",
-    "sbt.",
-    "*",
-    "com.sun."
+    "re:(cats|fs2)\\."
+    "re:(java|scala)\\."
+    "org.apache"
+    "com.fortyseven"
+    "*"
   ]
 }

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,41 +1,45 @@
-version = "3.7.4"
+version = "3.7.17"
 
-maxColumn = 150
+maxColumn = 120
 
-continuationIndent.callSite = 2
+align.preset = none
 
-runner {
-  dialect = scala3
-}
+assumeStandardLibraryStripMargin = true
+
+importSelectors = singleLine
+
+indentOperator.exemptScope = all
+
+rewrite.redundantBraces.ifElseExpressions = true
+rewrite.rules = [RedundantBraces, SortModifiers]
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.insertEndMarkerMinLines = 15
+rewrite.scala3.removeEndMarkerMaxLines = 14
+rewrite.scala3.removeOptionalBraces = oldSyntaxToo
+
+newlines.afterCurlyLambdaParams = squash
+newlines.inInterpolation = oneLine
+newlines.selectChains = unfold
+newlines.source = fold
+newlines.topLevelStatementBlankLines = [{blanks = 1}]
+
+runner.dialect = scala3
+runner.optimizer.forceConfigStyleMinArgCount = 3
+runner.optimizer.forceConfigStyleOnOffset = 120
+
+project.git = true
+project.includePaths = [
+  "glob:**.scala"
+  "glob:**.sbt"
+  "glob:**.sc"
+  "glob:**.md"
+]
 
 fileOverride {
-  "glob:**.sbt" {
-    runner.dialect = scala213
+  "glob:**/project/**" {
+    runner.dialect = scala212
   }
-  "glob:**/project/**.scala" {
-    runner.dialect = scala213
+  "glob:**/*.sbt" {
+    runner.dialect = scala212
   }
-}
-
-newlines {
-  sometimesBeforeColonInMethodReturnType = false
-}
-
-align {
-  arrowEnumeratorGenerator = true
-  ifWhileOpenParen = false
-  openParenCallSite = true
-  openParenDefnSite = true
-  preset = more
-}
-
-docstrings.style = Asterisk
-
-rewrite {
-  rules = [RedundantBraces]
-  redundantBraces.maxLines = 1
-}
-
-optIn {
-  breaksInsideChains = true
 }

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/app/AppCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/app/AppCodecs.scala
@@ -24,42 +24,35 @@ import com.fortyseven.domain.model.app.model.*
 
 import vulcan.Codec
 
-/**
- * It contains the Vulcan codecs for the types (enums, case classes...) defined in the object [[com.fortyseven.domain.model.app.model]].
- */
+/** It contains the Vulcan codecs for the types (enums, case classes...) defined in the object
+  * [[com.fortyseven.domain.model.app.model]].
+  */
 object AppCodecs:
 
   private val _namespace = "app"
 
-  given totalDistanceByTripCodec: Codec[TotalDistanceByTrip] =
-    Codec.record("TotalDistanceByTrip", _namespace) { totalDistanceByTrip =>
-      (
-        totalDistanceByTrip("tripId", _.tripId),
-        totalDistanceByTrip("distance", _.distance)
-      ).mapN(TotalDistanceByTrip.apply)
+  given totalDistanceByTripCodec: Codec[TotalDistanceByTrip] = Codec
+    .record("TotalDistanceByTrip", _namespace) { totalDistanceByTrip =>
+      (totalDistanceByTrip("tripId", _.tripId), totalDistanceByTrip("distance", _.distance))
+        .mapN(TotalDistanceByTrip.apply)
     }
 
-  given totalDistanceByUserCodec: Codec[TotalDistanceByUser] =
-    Codec.record("TotalDistanceByUser", _namespace) { totalDistanceByUser =>
-      (
-        totalDistanceByUser("userId", _.userId),
-        totalDistanceByUser("distance", _.distance)
-      ).mapN(TotalDistanceByUser.apply)
+  given totalDistanceByUserCodec: Codec[TotalDistanceByUser] = Codec
+    .record("TotalDistanceByUser", _namespace) { totalDistanceByUser =>
+      (totalDistanceByUser("userId", _.userId), totalDistanceByUser("distance", _.distance))
+        .mapN(TotalDistanceByUser.apply)
     }
 
-  given currentSpeedCodec: Codec[CurrentSpeed] =
-    Codec.record("CurrentSpeed", _namespace) { currentSpeed =>
-      (
-        currentSpeed("tripId", _.tripId),
-        currentSpeed("speed", _.speed)
-      ).mapN(CurrentSpeed.apply)
-    }
+  given currentSpeedCodec: Codec[CurrentSpeed] = Codec.record("CurrentSpeed", _namespace) { currentSpeed =>
+    (currentSpeed("tripId", _.tripId), currentSpeed("speed", _.speed)).mapN(CurrentSpeed.apply)
+  }
 
-  given totalRangeCodec: Codec[TotalRange] =
-    Codec.record("TotalRange", _namespace) { totalRange =>
-      (
-        totalRange("tripId", _.tripId),
-        totalRange("bicycleId", _.bicycleId),
-        totalRange("remainingRange", _.remainingRange)
-      ).mapN(TotalRange.apply)
-    }
+  given totalRangeCodec: Codec[TotalRange] = Codec.record("TotalRange", _namespace) { totalRange =>
+    (
+      totalRange("tripId", _.tripId),
+      totalRange("bicycleId", _.bicycleId),
+      totalRange("remainingRange", _.remainingRange)
+    ).mapN(TotalRange.apply)
+  }
+
+end AppCodecs

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/app/AppCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/app/AppCodecs.scala
@@ -21,6 +21,7 @@ import cats.implicits.*
 import com.fortyseven.domain.codecs.ids.IdsCodecs.given
 import com.fortyseven.domain.codecs.types.TypesCodecs.given
 import com.fortyseven.domain.model.app.model.*
+
 import vulcan.Codec
 
 /**

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/ids/IdsCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/ids/IdsCodecs.scala
@@ -16,7 +16,10 @@
 
 package com.fortyseven.domain.codecs.ids
 
-import com.fortyseven.domain.model.types.ids.{BicycleId, TripId, UserId}
+import com.fortyseven.domain.model.types.ids.BicycleId
+import com.fortyseven.domain.model.types.ids.TripId
+import com.fortyseven.domain.model.types.ids.UserId
+
 import vulcan.Codec
 
 /**

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/ids/IdsCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/ids/IdsCodecs.scala
@@ -22,9 +22,9 @@ import com.fortyseven.domain.model.types.ids.UserId
 
 import vulcan.Codec
 
-/**
- * It contains the Vulcan codecs for the types (enums, case classes...) defined in the object [[com.fortyseven.domain.model.types.ids]].
- */
+/** It contains the Vulcan codecs for the types (enums, case classes...) defined in the object
+  * [[com.fortyseven.domain.model.types.ids]].
+  */
 object IdsCodecs:
 
   given bicycleIdCodec: Codec[BicycleId] = Codec.uuid.imap(BicycleId.apply)(_.value)

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotCodecs.scala
@@ -16,12 +16,13 @@
 
 package com.fortyseven.domain.codecs.iot
 
-import scala.concurrent.duration.*
-
 import cats.implicits.*
+
+import scala.concurrent.duration.*
 
 import com.fortyseven.domain.codecs.types.TypesCodecs.given
 import com.fortyseven.domain.model.iot.model.*
+
 import vulcan.Codec
 
 /**

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotCodecs.scala
@@ -25,41 +25,35 @@ import com.fortyseven.domain.model.iot.model.*
 
 import vulcan.Codec
 
-/**
- * It contains the Vulcan codecs for the types (enums, case classes...) defined in the object [[com.fortyseven.domain.model.iot.model]].
- */
+/** It contains the Vulcan codecs for the types (enums, case classes...) defined in the object
+  * [[com.fortyseven.domain.model.iot.model]].
+  */
 object IotCodecs:
 
   private val _namespace = "iot"
 
-  given gpsPositionCodec: Codec[GPSPosition] =
-    Codec.record(name = "GPSPosition", namespace = _namespace) { field =>
-      (
-        field("latitude", _.latitude),
-        field("longitude", _.longitude)
-      ).mapN(GPSPosition.apply)
-    }
+  given gpsPositionCodec: Codec[GPSPosition] = Codec.record(name = "GPSPosition", namespace = _namespace) { field =>
+    (field("latitude", _.latitude), field("longitude", _.longitude)).mapN(GPSPosition.apply)
+  }
 
-  given wheelRotationCodec: Codec[WheelRotation] =
-    Codec.record(name = "WheelRotation", namespace = _namespace)(_("s", _.frequency).map(WheelRotation.apply))
+  given wheelRotationCodec: Codec[WheelRotation] = Codec
+    .record(name = "WheelRotation", namespace = _namespace)(_("s", _.frequency).map(WheelRotation.apply))
 
-  given batteryChargeCodec: Codec[BatteryCharge] =
-    Codec.record(name = "BatteryCharge", namespace = _namespace)(_("percentage", _.percentage).map(BatteryCharge.apply))
+  given batteryChargeCodec: Codec[BatteryCharge] = Codec
+    .record(name = "BatteryCharge", namespace = _namespace)(_("percentage", _.percentage).map(BatteryCharge.apply))
 
-  given batteryHealthCodec: Codec[BatteryHealth] =
-    Codec.record(name = "BatteryHealth", namespace = _namespace)(_("remaining", _.remaining).map(BatteryHealth.apply))
+  given batteryHealthCodec: Codec[BatteryHealth] = Codec
+    .record(name = "BatteryHealth", namespace = _namespace)(_("remaining", _.remaining).map(BatteryHealth.apply))
 
-  given pneumaticPressureCodec: Codec[PneumaticPressure] =
-    Codec.record(name = "PneumaticPressure", namespace = _namespace)(
-      _("pressure", _.pressure).map(PneumaticPressure.apply)
-    )
+  given pneumaticPressureCodec: Codec[PneumaticPressure] = Codec
+    .record(name = "PneumaticPressure", namespace = _namespace)(_("pressure", _.pressure).map(PneumaticPressure.apply))
 
   given finiteDurationCodec: Codec[FiniteDuration] = Codec.long.imap(_.millis)(_.toMillis)
 
-  given breaksUsageCodec: Codec[BreaksUsage] =
-    Codec.record(name = "BreaksUsage", namespace = _namespace)(
-      _("finateDuration", _.finiteDuration).map(BreaksUsage.apply)
-    )
+  given breaksUsageCodec: Codec[BreaksUsage] = Codec
+    .record(name = "BreaksUsage", namespace = _namespace)(_("finateDuration", _.finiteDuration).map(BreaksUsage.apply))
 
-  given breaksHealthCodec: Codec[BreaksHealth] =
-    Codec.record(name = "BreaksHealth", namespace = _namespace)(_("remaining", _.remaining).map(BreaksHealth.apply))
+  given breaksHealthCodec: Codec[BreaksHealth] = Codec
+    .record(name = "BreaksHealth", namespace = _namespace)(_("remaining", _.remaining).map(BreaksHealth.apply))
+
+end IotCodecs

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotErrorCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotErrorCodecs.scala
@@ -20,12 +20,12 @@ import com.fortyseven.domain.model.iot.errors.OutOfBoundsError
 
 import vulcan.Codec
 
-/**
- * It contains the Vulcan codecs for the types (enums, case classes...) defined in the object [[com.fortyseven.domain.model.iot.errors]].
- */
+/** It contains the Vulcan codecs for the types (enums, case classes...) defined in the object
+  * [[com.fortyseven.domain.model.iot.errors]].
+  */
 object IotErrorCodecs:
 
   private val _namespace = "iot-error"
 
-  given outOfBoundsErrorCodec: Codec[OutOfBoundsError] =
-    Codec.record(name = "OutOfBoundsError", namespace = _namespace)(_("msg", _.message).map(OutOfBoundsError.apply))
+  given outOfBoundsErrorCodec: Codec[OutOfBoundsError] = Codec
+    .record(name = "OutOfBoundsError", namespace = _namespace)(_("msg", _.message).map(OutOfBoundsError.apply))

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotErrorCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/iot/IotErrorCodecs.scala
@@ -17,6 +17,7 @@
 package com.fortyseven.domain.codecs.iot
 
 import com.fortyseven.domain.model.iot.errors.OutOfBoundsError
+
 import vulcan.Codec
 
 /**

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/types/TypesCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/types/TypesCodecs.scala
@@ -19,7 +19,9 @@ package com.fortyseven.domain.codecs.types
 import cats.implicits.*
 
 import com.fortyseven.domain.model.types.refinedTypes.*
-import vulcan.{AvroError, Codec}
+
+import vulcan.AvroError
+import vulcan.Codec
 
 /**
  * It contains the Vulcan codecs for the types (enums, case classes...) defined in the object [[com.fortyseven.domain.model.types.refinedTypes]].

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/types/TypesCodecs.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/codecs/types/TypesCodecs.scala
@@ -23,26 +23,37 @@ import com.fortyseven.domain.model.types.refinedTypes.*
 import vulcan.AvroError
 import vulcan.Codec
 
-/**
- * It contains the Vulcan codecs for the types (enums, case classes...) defined in the object [[com.fortyseven.domain.model.types.refinedTypes]].
- */
+/** It contains the Vulcan codecs for the types (enums, case classes...) defined in the object
+  * [[com.fortyseven.domain.model.types.refinedTypes]].
+  */
 object TypesCodecs:
 
-  given latitudeCodec: Codec[Latitude] =
-    Codec.double.imapError(Latitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given latitudeCodec: Codec[Latitude] = Codec
+    .double
+    .imapError(Latitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
 
-  given longitudeCodec: Codec[Longitude] =
-    Codec.double.imapError(Longitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given longitudeCodec: Codec[Longitude] = Codec
+    .double
+    .imapError(Longitude.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
 
-  given percentageCodec: Codec[Percentage] =
-    Codec.double.imapError(Percentage.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given percentageCodec: Codec[Percentage] = Codec
+    .double
+    .imapError(Percentage.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
 
-  given speedCodec: Codec[Speed] =
-    Codec.double.imapError(Speed.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given speedCodec: Codec[Speed] = Codec
+    .double
+    .imapError(Speed.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
 
-  given hertzCodec: Codec[Hz] = Codec.double.imapError(Hz.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given hertzCodec: Codec[Hz] = Codec
+    .double
+    .imapError(Hz.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
 
-  given barCodec: Codec[Bar] = Codec.double.imapError(Bar.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given barCodec: Codec[Bar] = Codec
+    .double
+    .imapError(Bar.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
 
-  given metersCodec: Codec[Meters] =
-    Codec.int.imapError(Meters.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+  given metersCodec: Codec[Meters] = Codec
+    .int
+    .imapError(Meters.from(_).leftMap(e => AvroError(s"AvroError: ${e.message}")))(_.value)
+
+end TypesCodecs

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/app/model.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/app/model.scala
@@ -16,8 +16,11 @@
 
 package com.fortyseven.domain.model.app
 
-import com.fortyseven.domain.model.types.ids.{BicycleId, TripId, UserId}
-import com.fortyseven.domain.model.types.refinedTypes.{Meters, Speed}
+import com.fortyseven.domain.model.types.ids.BicycleId
+import com.fortyseven.domain.model.types.ids.TripId
+import com.fortyseven.domain.model.types.ids.UserId
+import com.fortyseven.domain.model.types.refinedTypes.Meters
+import com.fortyseven.domain.model.types.refinedTypes.Speed
 
 /**
  * Contains case classes that represent aggregated data.

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/app/model.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/app/model.scala
@@ -22,59 +22,56 @@ import com.fortyseven.domain.model.types.ids.UserId
 import com.fortyseven.domain.model.types.refinedTypes.Meters
 import com.fortyseven.domain.model.types.refinedTypes.Speed
 
-/**
- * Contains case classes that represent aggregated data.
- */
+/** Contains case classes that represent aggregated data.
+  */
 object model:
 
-  /**
-   * Total distance of a given trip ID expressed in meters.
-   *
-   * @constructor
-   *   Create a TotalDistanceByTrip with a specified `tripId` and `distance`.
-   * @param tripId
-   *   key of the aggregation.
-   * @param distance
-   *   value of the aggregation, in meters.
-   */
+  /** Total distance of a given trip ID expressed in meters.
+    *
+    * @constructor
+    *   Create a TotalDistanceByTrip with a specified `tripId` and `distance`.
+    * @param tripId
+    *   key of the aggregation.
+    * @param distance
+    *   value of the aggregation, in meters.
+    */
   final case class TotalDistanceByTrip(tripId: TripId, distance: Meters)
 
-  /**
-   * Total distance cycled by a given user.
-   *
-   * @constructor
-   *   Create a TotalDistanceByUser with a specified `userId` and `distance`.
-   * @param userId
-   *   Key of the aggregation.
-   * @param distance
-   *   Distance cycled in meters for the given user ID.
-   */
+  /** Total distance cycled by a given user.
+    *
+    * @constructor
+    *   Create a TotalDistanceByUser with a specified `userId` and `distance`.
+    * @param userId
+    *   Key of the aggregation.
+    * @param distance
+    *   Distance cycled in meters for the given user ID.
+    */
   final case class TotalDistanceByUser(userId: UserId, distance: Meters)
 
-  /**
-   * Current speed of the given trip ID.
-   *
-   * @constructor
-   *   Create a CurrentSpeed with a specified `tripId` and `speed`
-   * @param tripId
-   *   Key of the aggregation.
-   * @param speed
-   *   Speed at the given moment for the given tripId.
-   * @todo
-   *   maybe a new parameter with a timestamp should be added to capture the time of the speed in the bicycle.
-   */
+  /** Current speed of the given trip ID.
+    *
+    * @constructor
+    *   Create a CurrentSpeed with a specified `tripId` and `speed`
+    * @param tripId
+    *   Key of the aggregation.
+    * @param speed
+    *   Speed at the given moment for the given tripId.
+    * @todo
+    *   maybe a new parameter with a timestamp should be added to capture the time of the speed in the bicycle.
+    */
   final case class CurrentSpeed(tripId: TripId, speed: Speed)
 
-  /**
-   * Total range of the given bicycle for the given trip.
-   *
-   * @constructor
-   *   Create a TotalRange with a specified `tripId`, `bicycleId` and `remainingRange`.
-   * @param tripId
-   *   Key of the aggregation.
-   * @param bicycleId
-   *   Bicycle identifier.
-   * @param remainingRange
-   *   Remaining range in meters calculated from the remaining energy in the battery.
-   */
+  /** Total range of the given bicycle for the given trip.
+    *
+    * @constructor
+    *   Create a TotalRange with a specified `tripId`, `bicycleId` and `remainingRange`.
+    * @param tripId
+    *   Key of the aggregation.
+    * @param bicycleId
+    *   Bicycle identifier.
+    * @param remainingRange
+    *   Remaining range in meters calculated from the remaining energy in the battery.
+    */
   final case class TotalRange(tripId: TripId, bicycleId: BicycleId, remainingRange: Meters)
+
+end model

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/iot/errors.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/iot/errors.scala
@@ -35,4 +35,4 @@ object errors:
    * @param message
    *   Reason for the OutOfBoundsError.
    */
-  final case class OutOfBoundsError(message: String) extends RuntimeException(message) with NoStackTrace
+    final case class OutOfBoundsError(message: String) extends RuntimeException(message) with NoStackTrace

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/iot/errors.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/iot/errors.scala
@@ -18,21 +18,21 @@ package com.fortyseven.domain.model.iot
 
 import scala.util.control.NoStackTrace
 
-/**
- * Contains possible errors for the application domain.
- */
+/** Contains possible errors for the application domain.
+  */
 object errors:
 
-  /**
-   * Represents the OutOfBoundsError with a cause in the message.
-   *
-   * Extends [[java.lang.RuntimeException]].
-   *
-   * Extends [[scala.util.control.NoStackTrace]].
-   *
-   * @constructor
-   *   Creates an OutOfBoundsError with a specified `message`.
-   * @param message
-   *   Reason for the OutOfBoundsError.
-   */
-    final case class OutOfBoundsError(message: String) extends RuntimeException(message) with NoStackTrace
+  /** Represents the OutOfBoundsError with a cause in the message.
+    *
+    * Extends [[java.lang.RuntimeException]].
+    *
+    * Extends [[scala.util.control.NoStackTrace]].
+    *
+    * @constructor
+    *   Creates an OutOfBoundsError with a specified `message`.
+    * @param message
+    *   Reason for the OutOfBoundsError.
+    */
+  final case class OutOfBoundsError(message: String) extends RuntimeException(message) with NoStackTrace
+
+end errors

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/iot/model.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/iot/model.scala
@@ -20,85 +20,79 @@ import scala.concurrent.duration.FiniteDuration
 
 import com.fortyseven.domain.model.types.refinedTypes.*
 
-/**
- * Contains final case classes that represent atomic information captured by sensors.
- */
+/** Contains final case classes that represent atomic information captured by sensors.
+  */
 object model:
 
-  /**
-   * GPSPosition.
-   *
-   * @constructor
-   *   Create a GPSPosition with a specified `latitude` and `longitude`.
-   *
-   * @param latitude
-   *   Expressed in a refined type that is a subset of Double (-90.0, 90.0).
-   * @param longitude
-   *   Expressed in a refined type that is a subset of Double (-180.0, 180.0).
-   */
+  /** GPSPosition.
+    *
+    * @constructor
+    *   Create a GPSPosition with a specified `latitude` and `longitude`.
+    *
+    * @param latitude
+    *   Expressed in a refined type that is a subset of Double (-90.0, 90.0).
+    * @param longitude
+    *   Expressed in a refined type that is a subset of Double (-180.0, 180.0).
+    */
   final case class GPSPosition(latitude: Latitude, longitude: Longitude)
 
-  /**
-   * WheelRotation
-   *
-   * @constructor
-   *   Create a WheelRotation with a specified `frequency`.
-   * @param frequency
-   *   Expressed in a refined type, that is a subset of Double (>=0.0).
-   */
+  /** WheelRotation
+    *
+    * @constructor
+    *   Create a WheelRotation with a specified `frequency`.
+    * @param frequency
+    *   Expressed in a refined type, that is a subset of Double (>=0.0).
+    */
   final case class WheelRotation(frequency: Hz)
 
-  /**
-   * BatteryCharge.
-   *
-   * @constructor
-   *   Create a BatteryCharge with a specified `percentage`.
-   *
-   * @param percentage
-   *   Expressed in a refined type that is a subset of Double (0.00, 100.00).
-   */
+  /** BatteryCharge.
+    *
+    * @constructor
+    *   Create a BatteryCharge with a specified `percentage`.
+    *
+    * @param percentage
+    *   Expressed in a refined type that is a subset of Double (0.00, 100.00).
+    */
   final case class BatteryCharge(percentage: Percentage)
 
-  /**
-   * BatteryHealth.
-   *
-   * @constructor
-   *   Create a BatteryHealth with a specified `remaining`.
-   *
-   * @param remaining
-   *   Expressed in a refined type that is a subset of Double (0.0, 100.0).
-   */
+  /** BatteryHealth.
+    *
+    * @constructor
+    *   Create a BatteryHealth with a specified `remaining`.
+    *
+    * @param remaining
+    *   Expressed in a refined type that is a subset of Double (0.0, 100.0).
+    */
   final case class BatteryHealth(remaining: Percentage)
 
-  /**
-   * PneumaticPressure.
-   *
-   * @constructor
-   *   Create a PneumaticPressure with a specified `pressure`.
-   *
-   * @param pressure
-   *   Expressed in a refined type that is a subset of Double (>=0.0).
-   */
+  /** PneumaticPressure.
+    *
+    * @constructor
+    *   Create a PneumaticPressure with a specified `pressure`.
+    *
+    * @param pressure
+    *   Expressed in a refined type that is a subset of Double (>=0.0).
+    */
   final case class PneumaticPressure(pressure: Bar)
 
-  /**
-   * BreaksUsage.
-   *
-   * @constructor
-   *   Create a BreaksUsage with a specified `finiteDuration`.
-   *
-   * @param finiteDuration
-   *   Expressed in seconds [[scala.concurrent.duration.FiniteDuration]].
-   */
+  /** BreaksUsage.
+    *
+    * @constructor
+    *   Create a BreaksUsage with a specified `finiteDuration`.
+    *
+    * @param finiteDuration
+    *   Expressed in seconds [[scala.concurrent.duration.FiniteDuration]].
+    */
   final case class BreaksUsage(finiteDuration: FiniteDuration)
 
-  /**
-   * BreaksHealth.
-   *
-   * @constructor
-   *   Create a BreaksHealth with a specified `remaining`.
-   *
-   * @param remaining
-   *   Expressed in a refined type that is a subset of Double (0.0, 100.0).
-   */
+  /** BreaksHealth.
+    *
+    * @constructor
+    *   Create a BreaksHealth with a specified `remaining`.
+    *
+    * @param remaining
+    *   Expressed in a refined type that is a subset of Double (0.0, 100.0).
+    */
   final case class BreaksHealth(remaining: Percentage)
+
+end model

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/ids.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/ids.scala
@@ -18,9 +18,8 @@ package com.fortyseven.domain.model.types
 
 import java.util.UUID
 
-/**
- * Contains the ids for the business domain.
- */
+/** Contains the ids for the business domain.
+  */
 object ids:
 
   opaque type BicycleId = UUID
@@ -29,80 +28,79 @@ object ids:
 
   opaque type TripId = UUID
 
-  /**
-   * Factory for [[BicycleId]] instances.
-   */
+  /** Factory for [[BicycleId]] instances.
+    */
   object BicycleId:
 
-    /**
-     * Builds a BicycleId from an UUID value.
-     *
-     * @param id
-     *   an UUID.
-     * @return
-     *   the id typed as BicycleId.
-     */
+    /** Builds a BicycleId from an UUID value.
+      *
+      * @param id
+      *   an UUID.
+      * @return
+      *   the id typed as BicycleId.
+      */
     def apply(id: UUID): BicycleId = id
 
     extension (bicycleId: BicycleId)
-      /**
-       * Exposes the bicycle ID as the underlying UUID type.
-       *
-       * @return
-       *   an UUID.
-       * @see
-       *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
-       */
+      /** Exposes the bicycle ID as the underlying UUID type.
+        *
+        * @return
+        *   an UUID.
+        * @see
+        *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
+        */
       def value: UUID = bicycleId
 
-  /**
-   * Factory for [[UserId]] instances.
-   */
+  end BicycleId
+
+  /** Factory for [[UserId]] instances.
+    */
   object UserId:
 
-    /**
-     * Builds a UserId from an UUID value.
-     *
-     * @param id
-     *   an UUID.
-     * @return
-     *   the id typed as UserId.
-     */
+    /** Builds a UserId from an UUID value.
+      *
+      * @param id
+      *   an UUID.
+      * @return
+      *   the id typed as UserId.
+      */
     def apply(id: UUID): UserId = id
 
     extension (userId: UserId)
-      /**
-       * Exposes the user ID as the underlying UUID type.
-       *
-       * @return
-       *   un UUID.
-       * @see
-       *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
-       */
+      /** Exposes the user ID as the underlying UUID type.
+        *
+        * @return
+        *   un UUID.
+        * @see
+        *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
+        */
       def value: UUID = userId
 
-  /**
-   * Factory for [[TripId]] instances.
-   */
+  end UserId
+
+  /** Factory for [[TripId]] instances.
+    */
   object TripId:
 
-    /**
-     * Builds a TripId from an UUID value.
-     *
-     * @param tripID
-     *   an UUID.
-     * @return
-     *   the trip ID typed as TripId.
-     */
+    /** Builds a TripId from an UUID value.
+      *
+      * @param tripID
+      *   an UUID.
+      * @return
+      *   the trip ID typed as TripId.
+      */
     def apply(tripID: UUID): TripId = tripID
 
     extension (tripId: TripId)
-      /**
-       * Exposes the trip ID as the underlying UUID type.
-       *
-       * @return
-       *   an UUID.
-       * @see
-       *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
-       */
+      /** Exposes the trip ID as the underlying UUID type.
+        *
+        * @return
+        *   an UUID.
+        * @see
+        *   [[https://docs.scala-lang.org/scala3/reference/contextual/extension-methods.html]].
+        */
       def value: UUID = tripId
+
+  end TripId
+
+end ids

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/refinedTypes.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/refinedTypes.scala
@@ -16,7 +16,8 @@
 
 package com.fortyseven.domain.model.types
 
-import scala.compiletime.{error, requireConst}
+import scala.compiletime.error
+import scala.compiletime.requireConst
 
 import com.fortyseven.domain.model.iot.errors.*
 

--- a/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/refinedTypes.scala
+++ b/01-c-domain/src/main/scala/com/fortyseven/domain/model/types/refinedTypes.scala
@@ -21,20 +21,19 @@ import scala.compiletime.requireConst
 
 import com.fortyseven.domain.model.iot.errors.*
 
-/**
- * Contains the types of the business logic.
- *
- * __Factories of the refined types:__
- *
- * The companion objects of the types have two constructors: `from` and `apply`.
- *
- *   - `from` is used for unknown values and it catches an exception at runtime if the values are not valid.
- *
- *   - `apply` is used for ''magic numbers'' and it verifies the validity of the value at compile time using inlining.
- *
- * @see
- *   inline internals at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
- */
+/** Contains the types of the business logic.
+  *
+  * __Factories of the refined types:__
+  *
+  * The companion objects of the types have two constructors: `from` and `apply`.
+  *
+  *   - `from` is used for unknown values and it catches an exception at runtime if the values are not valid.
+  *
+  *   - `apply` is used for ''magic numbers'' and it verifies the validity of the value at compile time using inlining.
+  *
+  * @see
+  *   inline internals at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+  */
 object refinedTypes:
 
   opaque type Latitude = Double
@@ -51,246 +50,241 @@ object refinedTypes:
 
   opaque type Meters = Int
 
-  /**
-   * Factory for [[Latitude]] instances.
-   */
+  /** Factory for [[Latitude]] instances.
+    */
   object Latitude:
 
-    /**
-     * Smart constructor for unknown doubles at compile time.
-     *
-     * @param coordinateCandidate
-     *   An unknown double.
-     * @return
-     *   An Either with a Right Latitude or a Left OutOfBoundsError.
-     */
+    /** Smart constructor for unknown doubles at compile time.
+      *
+      * @param coordinateCandidate
+      *   An unknown double.
+      * @return
+      *   An Either with a Right Latitude or a Left OutOfBoundsError.
+      */
     def from(coordinateCandidate: Double): Either[OutOfBoundsError, Latitude] = coordinateCandidate match
       case c if c < -90.0 || c > 90.0 => Left(OutOfBoundsError(s"Invalid latitude value $c"))
-      case c                          => Right(c)
+      case c => Right(c)
 
-    /**
-     * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param coordinate
-     *   A known double.
-     * @return
-     *   A valid Latitude or a compiler error.
-     * @see
-     *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param coordinate
+      *   A known double.
+      * @return
+      *   A valid Latitude or a compiler error.
+      * @see
+      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(coordinate: Double): Latitude =
       requireConst(coordinate)
-      inline if coordinate < -90.0 || coordinate > 90.0
-      then error("Invalid latitude value. Accepted coordinate values are between -90.0 and 90.0.")
+      inline if coordinate < -90.0 || coordinate > 90.0 then
+        error("Invalid latitude value. Accepted coordinate values are between -90.0 and 90.0.")
       else coordinate
 
     extension (coordinate: Latitude) def value: Double = coordinate
 
-  /**
-   * Factory for [[Longitude]] instances.
-   */
+  end Latitude
+
+  /** Factory for [[Longitude]] instances.
+    */
   object Longitude:
 
-    /**
-     * Smart constructor for unknown doubles at compile time.
-     *
-     * @param coordinateCandidate
-     *   An unknown double.
-     * @return
-     *   An Either with a Right Longitude or a Left OutOfBoundsError.
-     */
+    /** Smart constructor for unknown doubles at compile time.
+      *
+      * @param coordinateCandidate
+      *   An unknown double.
+      * @return
+      *   An Either with a Right Longitude or a Left OutOfBoundsError.
+      */
     def from(coordinateCandidate: Double): Either[OutOfBoundsError, Longitude] = coordinateCandidate match
       case c if c < -180.0 || c > 180.0 => Left(OutOfBoundsError(s"Invalid longitude value $c"))
-      case c                            => Right(c)
+      case c => Right(c)
 
-    /**
-     * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param coordinate
-     *   A known double.
-     * @return
-     *   A valid Longitude or a compiler error.
-     * @see
-     *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param coordinate
+      *   A known double.
+      * @return
+      *   A valid Longitude or a compiler error.
+      * @see
+      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(coordinate: Double): Longitude =
       requireConst(coordinate)
-      inline if coordinate < -180.0 || coordinate > 180.0
-      then error("Invalid longitude value. Accepted coordinate values are between -180.0 and 180.0.")
+      inline if coordinate < -180.0 || coordinate > 180.0 then
+        error("Invalid longitude value. Accepted coordinate values are between -180.0 and 180.0.")
       else coordinate
 
     extension (coordinate: Longitude) def value: Double = coordinate
 
-  /**
-   * Factory for [[Percentage]] instances.
-   */
+  end Longitude
+
+  /** Factory for [[Percentage]] instances.
+    */
   object Percentage:
 
-    /**
-     * Smart constructor for unknown doubles at compile time.
-     *
-     * @param percentageCandidate
-     *   An unknown double.
-     * @return
-     *   An Either with a Right Percentage or a Left OutOfBoundsError.
-     */
+    /** Smart constructor for unknown doubles at compile time.
+      *
+      * @param percentageCandidate
+      *   An unknown double.
+      * @return
+      *   An Either with a Right Percentage or a Left OutOfBoundsError.
+      */
     def from(percentageCandidate: Double): Either[OutOfBoundsError, Percentage] = percentageCandidate match
       case p if p < 0.0 || p > 100.0 => Left(OutOfBoundsError(s"Invalid percentage value $p"))
-      case percentage                => Right(percentage)
+      case percentage => Right(percentage)
 
-    /**
-     * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param percentage
-     *   A known double.
-     * @return
-     *   A valid Percentage or a compiler error.
-     * @see
-     *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param percentage
+      *   A known double.
+      * @return
+      *   A valid Percentage or a compiler error.
+      * @see
+      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(percentage: Double): Percentage =
       requireConst(percentage)
-      inline if percentage < 0.0 || percentage > 100.0
-      then error("Invalid percentage value. Accepted percentage values are between -0.0 and 100.0.")
+      inline if percentage < 0.0 || percentage > 100.0 then
+        error("Invalid percentage value. Accepted percentage values are between -0.0 and 100.0.")
       else percentage
 
     extension (percentage: Percentage) def value: Double = percentage
 
-  /**
-   * Factory for [[Speed]] instances.
-   */
+  end Percentage
+
+  /** Factory for [[Speed]] instances.
+    */
   object Speed:
 
-    /**
-     * Smart constructor for unknown doubles at compile time.
-     *
-     * @param speedCandidate
-     *   An unknown double.
-     * @return
-     *   An Either with a Right Speed or a Left OutOfBoundsError.
-     */
+    /** Smart constructor for unknown doubles at compile time.
+      *
+      * @param speedCandidate
+      *   An unknown double.
+      * @return
+      *   An Either with a Right Speed or a Left OutOfBoundsError.
+      */
     def from(speedCandidate: Double): Either[OutOfBoundsError, Speed] = speedCandidate match
       case speed if speed < 0.0 => Left(OutOfBoundsError(s"Invalid speed value $speed"))
-      case speed                => Right(speed)
+      case speed => Right(speed)
 
-    /**
-     * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param speed
-     *   A known double.
-     * @return
-     *   A valid Speed or a compiler error.
-     * @see
-     *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param speed
+      *   A known double.
+      * @return
+      *   A valid Speed or a compiler error.
+      * @see
+      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(speed: Double): Speed =
       requireConst(speed)
-      inline if speed < 0.0
-      then error("Invalid speed value. Accepted speed values are greater than 0.0.")
-      else speed
+      inline if speed < 0.0 then error("Invalid speed value. Accepted speed values are greater than 0.0.") else speed
 
     extension (speed: Speed) def value: Double = speed
 
-  /**
-   * Factory for [[Hz]] instances.
-   */
+  end Speed
+
+  /** Factory for [[Hz]] instances.
+    */
   object Hz:
 
-    /**
-     * Smart constructor for unknown doubles at compile time.
-     *
-     * @param hertzCandidate
-     *   An unknown double.
-     * @return
-     *   An Either with a Right Hz or a Left OutOfBoundsError.
-     */
+    /** Smart constructor for unknown doubles at compile time.
+      *
+      * @param hertzCandidate
+      *   An unknown double.
+      * @return
+      *   An Either with a Right Hz or a Left OutOfBoundsError.
+      */
     def from(hertzCandidate: Double): Either[OutOfBoundsError, Hz] = hertzCandidate match
       case hz if hz < 0.0 => Left(OutOfBoundsError(s"Invalid frequency value $hz"))
-      case hz             => Right(hz)
+      case hz => Right(hz)
 
-    /**
-     * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param hertz
-     *   A known double.
-     * @return
-     *   A valid Hz or a compiler error.
-     * @see
-     *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param hertz
+      *   A known double.
+      * @return
+      *   A valid Hz or a compiler error.
+      * @see
+      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(hertz: Double): Hz =
-      inline if hertz < 0.0
-      then error("Invalid frequency value. Accepted hertz values are greater than 0.0.")
+      inline if hertz < 0.0 then error("Invalid frequency value. Accepted hertz values are greater than 0.0.")
       else hertz
 
     extension (hertz: Hz) def value: Double = hertz
 
-  /**
-   * Factory for [[Bar]] instances.
-   */
+  end Hz
+
+  /** Factory for [[Bar]] instances.
+    */
   object Bar:
 
-    /**
-     * Smart constructor for unknown doubles at compile time.
-     *
-     * @param barCandidate
-     *   An unknown double.
-     * @return
-     *   An Either with a Right Bar or a Left OutOfBoundsError.
-     */
+    /** Smart constructor for unknown doubles at compile time.
+      *
+      * @param barCandidate
+      *   An unknown double.
+      * @return
+      *   An Either with a Right Bar or a Left OutOfBoundsError.
+      */
     def from(barCandidate: Double): Either[OutOfBoundsError, Bar] = barCandidate match
       case p if p < 0.0 => Left(OutOfBoundsError(s"Invalid pressure value $p"))
-      case p            => Right(p)
+      case p => Right(p)
 
-    /**
-     * Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param bar
-     *   A known double.
-     * @return
-     *   A valid Bar or a compiler error.
-     * @see
-     *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known doubles at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param bar
+      *   A known double.
+      * @return
+      *   A valid Bar or a compiler error.
+      * @see
+      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(bar: Double): Bar =
       requireConst(bar)
-      inline if bar < 0.0
-      then error("Invalid pressure value. Accepted bar values are greater than 0.0.")
-      else bar
+      inline if bar < 0.0 then error("Invalid pressure value. Accepted bar values are greater than 0.0.") else bar
 
     extension (bar: Bar) def value: Double = bar
 
-  /**
-   * Factory for [[Meters]] instances.
-   */
+  end Bar
+
+  /** Factory for [[Meters]] instances.
+    */
   object Meters:
 
-    /**
-     * Smart constructor for unknown integers at compile time.
-     *
-     * @param metersCandidate
-     *   An unknown integer.
-     * @return
-     *   An Either with a Right Meters or a Left OutOfBoundsError.
-     */
+    /** Smart constructor for unknown integers at compile time.
+      *
+      * @param metersCandidate
+      *   An unknown integer.
+      * @return
+      *   An Either with a Right Meters or a Left OutOfBoundsError.
+      */
     def from(metersCandidate: Int): Either[OutOfBoundsError, Meters] = metersCandidate match
       case meters if meters < 0 => Left(OutOfBoundsError(s"Invalid meters value $meters"))
-      case meters               => Right(meters)
+      case meters => Right(meters)
 
-    /**
-     * Smart constructor for known integers at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param meters
-     *   A known integer.
-     * @return
-     *   A valid Meters or a compiler error.
-     * @see
-     *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known integers at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param meters
+      *   A known integer.
+      * @return
+      *   A valid Meters or a compiler error.
+      * @see
+      *   [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(meters: Int): Meters =
       requireConst(meters)
-      inline if meters < 0
-      then error("Invalid meters value. Accepted bar values are greater than 0.")
-      else meters
+      inline if meters < 0 then error("Invalid meters value. Accepted bar values are greater than 0.") else meters
 
     extension (meters: Meters) def value: Int = meters
+
+  end Meters
+
+end refinedTypes

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/TestUtils.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/TestUtils.scala
@@ -23,8 +23,11 @@ import com.fortyseven.domain.model.app.model.*
 import com.fortyseven.domain.model.iot.model.*
 import com.fortyseven.domain.model.types.ids.*
 import com.fortyseven.domain.model.types.refinedTypes.*
-import org.scalacheck.{Arbitrary, Gen}
-import vulcan.{AvroError, Codec}
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import vulcan.AvroError
+import vulcan.Codec
 
 object TestUtils:
 

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/TestUtils.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/TestUtils.scala
@@ -39,17 +39,14 @@ object TestUtils:
 
   given Arbitrary[BicycleId] = Arbitrary(Gen.uuid.map(BicycleId.apply))
 
-  given Arbitrary[Latitude] = Arbitrary(
-    Gen.chooseNum[Double](-90.0, 90.0).flatMap(Latitude.from(_).fold(_ => Gen.fail, Gen.const))
-  )
+  given Arbitrary[Latitude] =
+    Arbitrary(Gen.chooseNum[Double](-90.0, 90.0).flatMap(Latitude.from(_).fold(_ => Gen.fail, Gen.const)))
 
-  given Arbitrary[Longitude] = Arbitrary(
-    Gen.chooseNum[Double](-180.0, 180.0).flatMap(Longitude.from(_).fold(_ => Gen.fail, Gen.const))
-  )
+  given Arbitrary[Longitude] =
+    Arbitrary(Gen.chooseNum[Double](-180.0, 180.0).flatMap(Longitude.from(_).fold(_ => Gen.fail, Gen.const)))
 
-  given Arbitrary[Percentage] = Arbitrary(
-    Gen.chooseNum[Double](0.0, 100.0).flatMap(Percentage.from(_).fold(_ => Gen.fail, Gen.const))
-  )
+  given Arbitrary[Percentage] =
+    Arbitrary(Gen.chooseNum[Double](0.0, 100.0).flatMap(Percentage.from(_).fold(_ => Gen.fail, Gen.const)))
 
   given Arbitrary[Speed] = Arbitrary(Gen.posNum[Double].flatMap(Speed.from(_).fold(_ => Gen.fail, Gen.const)))
 
@@ -59,28 +56,19 @@ object TestUtils:
 
   given Arbitrary[Meters] = Arbitrary(Gen.posNum[Int].flatMap(Meters.from(_).fold(_ => Gen.fail, Gen.const)))
 
-  given Arbitrary[TotalDistanceByTrip] = Arbitrary(
-    Gen.resultOf(TotalDistanceByTrip.apply)
-  )
+  given Arbitrary[TotalDistanceByTrip] = Arbitrary(Gen.resultOf(TotalDistanceByTrip.apply))
 
-  given Arbitrary[TotalDistanceByUser] = Arbitrary(
-    Gen.resultOf(TotalDistanceByUser.apply)
-  )
+  given Arbitrary[TotalDistanceByUser] = Arbitrary(Gen.resultOf(TotalDistanceByUser.apply))
 
   given Arbitrary[CurrentSpeed] = Arbitrary(Gen.resultOf(CurrentSpeed.apply))
 
-  given Arbitrary[TotalRange] = Arbitrary(
-    Gen.resultOf(TotalRange.apply)
-  )
+  given Arbitrary[TotalRange] = Arbitrary(Gen.resultOf(TotalRange.apply))
 
-  given Arbitrary[GPSPosition] = Arbitrary(
-    Gen.resultOf(GPSPosition.apply)
-  )
+  given Arbitrary[GPSPosition] = Arbitrary(Gen.resultOf(GPSPosition.apply))
 
   given Arbitrary[WheelRotation] = Arbitrary(Gen.resultOf(WheelRotation.apply))
 
-  given Arbitrary[BatteryCharge] =
-    Arbitrary(Gen.resultOf(BatteryCharge.apply))
+  given Arbitrary[BatteryCharge] = Arbitrary(Gen.resultOf(BatteryCharge.apply))
 
   given Arbitrary[BatteryHealth] = Arbitrary(Gen.resultOf(BatteryHealth.apply))
 
@@ -91,3 +79,5 @@ object TestUtils:
   given Arbitrary[BreaksHealth] = Arbitrary(Gen.resultOf(BreaksHealth.apply))
 
   def codeAndDecode[C: Codec](instance: C): Either[AvroError, C] = Codec.encode(instance).flatMap(Codec.decode[C])
+
+end TestUtils

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/app/AppCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/app/AppCodecsTest.scala
@@ -41,3 +41,5 @@ class AppCodecsTest extends ScalaCheckSuite:
   property("Total range should return the same value after encoding and decoding"):
     forAll: (totalRange: TotalRange) =>
       assertEquals(codeAndDecode(totalRange), Right(totalRange))
+
+end AppCodecsTest

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/app/AppCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/app/AppCodecsTest.scala
@@ -20,6 +20,7 @@ import com.fortyseven.domain.TestUtils.codeAndDecode
 import com.fortyseven.domain.TestUtils.given
 import com.fortyseven.domain.codecs.app.AppCodecs.given
 import com.fortyseven.domain.model.app.model.*
+
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.forAll
 

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/ids/IdsCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/ids/IdsCodecsTest.scala
@@ -16,12 +16,16 @@
 
 package com.fortyseven.domain.codecs.ids
 
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag
+import scala.reflect.classTag
 
 import com.fortyseven.domain.TestUtils.codeAndDecode
 import com.fortyseven.domain.TestUtils.given
 import com.fortyseven.domain.codecs.ids.IdsCodecs.given
-import com.fortyseven.domain.model.types.ids.{BicycleId, TripId, UserId}
+import com.fortyseven.domain.model.types.ids.BicycleId
+import com.fortyseven.domain.model.types.ids.TripId
+import com.fortyseven.domain.model.types.ids.UserId
+
 import munit.ScalaCheckSuite
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/iot/IotCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/iot/IotCodecsTest.scala
@@ -22,6 +22,7 @@ import com.fortyseven.domain.TestUtils.codeAndDecode
 import com.fortyseven.domain.TestUtils.given
 import com.fortyseven.domain.codecs.iot.IotCodecs.given
 import com.fortyseven.domain.model.iot.model.*
+
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.forAll
 

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/iot/IotCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/iot/IotCodecsTest.scala
@@ -55,3 +55,5 @@ class IotCodecsTest extends ScalaCheckSuite:
   property("BreaksHealth should return the same value after encoding and decoding"):
     forAll: (breaksHealth: BreaksHealth) =>
       assertEquals(codeAndDecode(breaksHealth), Right(breaksHealth))
+
+end IotCodecsTest

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/iot/IotErrorCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/iot/IotErrorCodecsTest.scala
@@ -16,14 +16,17 @@
 
 package com.fortyseven.domain.codecs.iot
 
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag
+import scala.reflect.classTag
 
 import com.fortyseven.domain.TestUtils.codeAndDecode
 import com.fortyseven.domain.codecs.iot.IotErrorCodecs.given
 import com.fortyseven.domain.model.iot.errors.OutOfBoundsError
+
 import munit.ScalaCheckSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
-import org.scalacheck.{Arbitrary, Gen}
 
 class IotErrorCodecsTest extends ScalaCheckSuite:
 

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/types/TypesCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/types/TypesCodecsTest.scala
@@ -48,3 +48,5 @@ class TypesCodecsTest extends ScalaCheckSuite:
   propCodec[Bar]()
 
   propCodec[Meters]()
+
+end TypesCodecsTest

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/types/TypesCodecsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/codecs/types/TypesCodecsTest.scala
@@ -16,12 +16,14 @@
 
 package com.fortyseven.domain.codecs.types
 
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag
+import scala.reflect.classTag
 
 import com.fortyseven.domain.TestUtils.codeAndDecode
 import com.fortyseven.domain.TestUtils.given
 import com.fortyseven.domain.codecs.types.TypesCodecs.given
 import com.fortyseven.domain.model.types.refinedTypes.*
+
 import munit.ScalaCheckSuite
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/idsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/idsTest.scala
@@ -42,3 +42,5 @@ class idsTest extends ScalaCheckSuite:
   property("TripId should build from a valid UUID and method call value should return the same UUID"):
     forAll: (uuid: UUID) =>
       assertEquals(TripId(uuid).value, uuid)
+
+end idsTest

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/idsTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/idsTest.scala
@@ -18,10 +18,14 @@ package com.fortyseven.domain.model.types
 
 import java.util.UUID
 
-import com.fortyseven.domain.model.types.ids.{BicycleId, TripId, UserId}
+import com.fortyseven.domain.model.types.ids.BicycleId
+import com.fortyseven.domain.model.types.ids.TripId
+import com.fortyseven.domain.model.types.ids.UserId
+
 import munit.ScalaCheckSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
-import org.scalacheck.{Arbitrary, Gen}
 
 class idsTest extends ScalaCheckSuite:
 

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/refinedTypesTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/refinedTypesTest.scala
@@ -17,6 +17,7 @@
 package com.fortyseven.domain.model.types
 
 import com.fortyseven.domain.model.types.refinedTypes.*
+
 import munit.ScalaCheckSuite
 import org.scalacheck
 import org.scalacheck.Gen

--- a/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/refinedTypesTest.scala
+++ b/01-c-domain/src/test/scala/com/fortyseven/domain/model/types/refinedTypesTest.scala
@@ -92,3 +92,5 @@ class refinedTypesTest extends ScalaCheckSuite:
   property("A valid Meters should have a value equal to 0 or higher"):
     forAll(Gen.posNum[Int]): meters =>
       Meters.from(meters).isRight
+
+end refinedTypesTest

--- a/02-c-api/src/main/scala/com/fortyseven/common/api/ConfigurationAPI.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/api/ConfigurationAPI.scala
@@ -16,21 +16,24 @@
 
 package com.fortyseven.common.api
 
-/**
- * The classes that extend this trait will make available the configuration of type [Configuration] inside a wrapper of type [Effect].
- *
- * The classes that extend this method are not a monad. They cannot be mapped or flatMapped - unless you import some hacks from the cats library.
- *
- * @tparam Effect
- *   This is the type of the wrapper, usually Async.
- * @tparam Configuration
- *   This is the type of the configuration that wants to be loaded.
- */
+/** The classes that extend this trait will make available the configuration of type [Configuration] inside a wrapper of
+  * type [Effect].
+  *
+  * The classes that extend this method are not a monad. They cannot be mapped or flatMapped - unless you import some
+  * hacks from the cats library.
+  *
+  * @tparam Effect
+  *   This is the type of the wrapper, usually Async.
+  * @tparam Configuration
+  *   This is the type of the configuration that wants to be loaded.
+  */
 trait ConfigurationAPI[Effect[_], Configuration]:
-  /**
-   * @return
-   *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the method is mappable or flatMappable
-   *   since it is wrapped into an effect. Thus, you can use it in a for-comprehension. If the value of the configuration fails to be loaded, the
-   *   effect will handle the error gracefully.
-   */
+  /** @return
+    *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the
+    *   method is mappable or flatMappable since it is wrapped into an effect. Thus, you can use it in a
+    *   for-comprehension. If the value of the configuration fails to be loaded, the effect will handle the error
+    *   gracefully.
+    */
   def load(): Effect[Configuration]
+
+end ConfigurationAPI

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/DataGeneratorConfigurationI.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/DataGeneratorConfigurationI.scala
@@ -18,7 +18,9 @@ package com.fortyseven.common.configuration
 
 import scala.concurrent.duration.FiniteDuration
 
-import com.fortyseven.common.configuration.refinedTypes.{KafkaCompressionType, NonEmptyString, PositiveInt}
+import com.fortyseven.common.configuration.refinedTypes.KafkaCompressionType
+import com.fortyseven.common.configuration.refinedTypes.NonEmptyString
+import com.fortyseven.common.configuration.refinedTypes.PositiveInt
 
 trait DataGeneratorConfigurationI:
   val kafka: DataGeneratorKafkaConfigurationI

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/FlinkProcessorConfigurationI.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/FlinkProcessorConfigurationI.scala
@@ -18,7 +18,10 @@ package com.fortyseven.common.configuration
 
 import scala.concurrent.duration.FiniteDuration
 
-import com.fortyseven.common.configuration.refinedTypes.{KafkaAutoOffsetReset, KafkaCompressionType, NonEmptyString, PositiveInt}
+import com.fortyseven.common.configuration.refinedTypes.KafkaAutoOffsetReset
+import com.fortyseven.common.configuration.refinedTypes.KafkaCompressionType
+import com.fortyseven.common.configuration.refinedTypes.NonEmptyString
+import com.fortyseven.common.configuration.refinedTypes.PositiveInt
 
 trait FlinkProcessorConfigurationI:
   val kafka: FlinkProcessorKafkaConfigurationI

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -23,205 +23,193 @@ import scala.compiletime.ops.int.*
 import scala.compiletime.ops.string.Matches
 import scala.util.Try
 
-/**
- * Before running the whole program or a part of it, the involved configuration must be loaded. Refining the types of the configuration's values
- * reduces the cardinality and helps catching an invalid configuration's value while loading.
- *
- * __Factories of the refined types:__
- *
- * The companion objects of the types have two constructors: `from` and `apply`.
- *
- *   - `from` is used for unknown values and it catches an exception at runtime if the values are not valid.
- *
- *   - `apply` is used for ''magic numbers'' and it verifies the validity of the value at compile time using inlining.
- *
- * @see
- *   inline internals at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
- */
+/** Before running the whole program or a part of it, the involved configuration must be loaded. Refining the types of
+  * the configuration's values reduces the cardinality and helps catching an invalid configuration's value while
+  * loading.
+  *
+  * __Factories of the refined types:__
+  *
+  * The companion objects of the types have two constructors: `from` and `apply`.
+  *
+  *   - `from` is used for unknown values and it catches an exception at runtime if the values are not valid.
+  *
+  *   - `apply` is used for ''magic numbers'' and it verifies the validity of the value at compile time using inlining.
+  *
+  * @see
+  *   inline internals at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+  */
 object refinedTypes:
 
-  /**
-   * Set of allowed compression types for Kafka producers.
-   *
-   * @see
-   *   [[https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#compression-type]]
-   */
+  /** Set of allowed compression types for Kafka producers.
+    *
+    * @see
+    *   [[https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#compression-type]]
+    */
   enum KafkaCompressionType:
 
     case none, gzip, snappy, lz4, zstd
 
-  /**
-   * Factory for [[KafkaCompressionType]] instances.
-   */
+  /** Factory for [[KafkaCompressionType]] instances.
+    */
   object KafkaCompressionType:
 
-    /**
-     * Smart constructor for unknown strings at compile time.
-     *
-     * @param kafkaCompressionTypeCandidate
-     *   An unknown string.
-     * @return
-     *   An Either with a Right KafkaCompressionType or a Left Throwable.
-     */
+    /** Smart constructor for unknown strings at compile time.
+      *
+      * @param kafkaCompressionTypeCandidate
+      *   An unknown string.
+      * @return
+      *   An Either with a Right KafkaCompressionType or a Left Throwable.
+      */
     def from(kafkaCompressionTypeCandidate: String): Either[Throwable, KafkaCompressionType] =
       Try(valueOf(kafkaCompressionTypeCandidate)).toEither
 
-    /**
-     * Smart constructor for known strings at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param kafkaCompressionType
-     *   A known string.
-     * @return
-     *   A valid KafkaCompressionType or a compiler error.
-     * @see
-     *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
-    inline def apply(kafkaCompressionType: String): KafkaCompressionType =
-      inline kafkaCompressionType match
-        case "none"   => none
-        case "gzip"   => gzip
-        case "snappy" => snappy
-        case "lz4"    => lz4
-        case "zstd"   => zstd
-        case _: String =>
-          error:
-            codeOf(kafkaCompressionType) + " is invalid.\nValid values are none, gzip, snappy, lz4 and zstd."
+    /** Smart constructor for known strings at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param kafkaCompressionType
+      *   A known string.
+      * @return
+      *   A valid KafkaCompressionType or a compiler error.
+      * @see
+      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
+    inline def apply(kafkaCompressionType: String): KafkaCompressionType = inline kafkaCompressionType match
+      case "none" => none
+      case "gzip" => gzip
+      case "snappy" => snappy
+      case "lz4" => lz4
+      case "zstd" => zstd
+      case _: String => error:
+          codeOf(kafkaCompressionType) + " is invalid.\nValid values are none, gzip, snappy, lz4 and zstd."
 
-  /**
-   * Set of allowed auto offset reset types for Kafka consumers.
-   *
-   * @see
-   *   [[https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#auto-offset-reset]]
-   */
+  end KafkaCompressionType
+
+  /** Set of allowed auto offset reset types for Kafka consumers.
+    *
+    * @see
+    *   [[https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#auto-offset-reset]]
+    */
   enum KafkaAutoOffsetReset:
 
     case earliest, latest, none
 
-  /**
-   * Factory for [[KafkaAutoOffsetReset]] instances.
-   */
+  /** Factory for [[KafkaAutoOffsetReset]] instances.
+    */
   object KafkaAutoOffsetReset:
 
-    /**
-     * Smart constructor for unknown strings at compile time.
-     *
-     * @param kafkaAutoOffsetResetCandidate
-     *   An unknown string.
-     * @return
-     *   An Either with a Right KafkaAutoOffsetReset or a Left IllegalStateException.
-     */
+    /** Smart constructor for unknown strings at compile time.
+      *
+      * @param kafkaAutoOffsetResetCandidate
+      *   An unknown string.
+      * @return
+      *   An Either with a Right KafkaAutoOffsetReset or a Left IllegalStateException.
+      */
     def from(kafkaAutoOffsetResetCandidate: String): Either[Throwable, KafkaAutoOffsetReset] =
       Try(valueOf(kafkaAutoOffsetResetCandidate)).toEither
 
-    /**
-     * Smart constructor for known strings at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param kafkaAutoOffsetReset
-     *   A known string.
-     * @return
-     *   A valid KafkaAutoOffsetReset or a compiler error.
-     * @see
-     *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
-    inline def apply(kafkaAutoOffsetReset: String): KafkaAutoOffsetReset =
-      inline kafkaAutoOffsetReset match
-        case "earliest" => earliest
-        case "latest"   => latest
-        case "none"     => none
-        case _: String =>
-          error:
-            codeOf(kafkaAutoOffsetReset) + " is invalid.\nValid values are earliest, latest and none."
+    /** Smart constructor for known strings at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param kafkaAutoOffsetReset
+      *   A known string.
+      * @return
+      *   A valid KafkaAutoOffsetReset or a compiler error.
+      * @see
+      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
+    inline def apply(kafkaAutoOffsetReset: String): KafkaAutoOffsetReset = inline kafkaAutoOffsetReset match
+      case "earliest" => earliest
+      case "latest" => latest
+      case "none" => none
+      case _: String => error:
+          codeOf(kafkaAutoOffsetReset) + " is invalid.\nValid values are earliest, latest and none."
 
-  /**
-   * Type alias for String. The validation happens in the factory methods of the companion object.
-   */
+  end KafkaAutoOffsetReset
+
+  /** Type alias for String. The validation happens in the factory methods of the companion object.
+    */
   opaque type NonEmptyString = String
 
-  /**
-   * Factory for [[NonEmptyString]] instances.
-   */
+  /** Factory for [[NonEmptyString]] instances.
+    */
   object NonEmptyString:
 
-    /**
-     * Smart constructor for unknown strings at compile time.
-     *
-     * @param nonEmptyStringCandidate
-     *   An unknown string.
-     * @return
-     *   An Either with a Right NonEmptyString or a Left IllegalStateException.
-     */
+    /** Smart constructor for unknown strings at compile time.
+      *
+      * @param nonEmptyStringCandidate
+      *   An unknown string.
+      * @return
+      *   An Either with a Right NonEmptyString or a Left IllegalStateException.
+      */
     def from(nonEmptyStringCandidate: String): Either[Throwable, NonEmptyString] =
-      if nonEmptyStringCandidate.isBlank
-      then Left(new IllegalStateException(s"The provided string $nonEmptyStringCandidate is empty."))
+      if nonEmptyStringCandidate.isBlank then
+        Left(new IllegalStateException(s"The provided string $nonEmptyStringCandidate is empty."))
       else Right(nonEmptyStringCandidate)
 
-    /**
-     * Smart constructor for known strings at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param nonEmptyString
-     *   A known string.
-     * @return
-     *   A valid NonEmptyString or a compiler error.
-     * @see
-     *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known strings at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param nonEmptyString
+      *   A known string.
+      * @return
+      *   A valid NonEmptyString or a compiler error.
+      * @see
+      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(nonEmptyString: String): NonEmptyString =
-      inline if constValue[Matches[nonEmptyString.type, "^\\S+$"]]
-      then nonEmptyString
+      inline if constValue[Matches[nonEmptyString.type, "^\\S+$"]] then nonEmptyString
       else error(codeOf(nonEmptyString) + " is invalid. Empty String is not allowed here.")
 
-    /**
-     * When the compiler expects a value of type String but it finds a value of type NonEmptyString, it executes this.
-     *
-     * @return
-     *   Value of type NonEmptyString as type String.
-     */
+    /** When the compiler expects a value of type String but it finds a value of type NonEmptyString, it executes this.
+      *
+      * @return
+      *   Value of type NonEmptyString as type String.
+      */
     given Conversion[NonEmptyString, String] with
       override def apply(x: NonEmptyString): String = x
 
-  /**
-   * Type alias for Int. The validation happens in the factory methods of the companion object.
-   */
+  end NonEmptyString
+
+  /** Type alias for Int. The validation happens in the factory methods of the companion object.
+    */
   opaque type PositiveInt = Int
 
-  /**
-   * Factory for [[PositiveInt]] instances.
-   */
+  /** Factory for [[PositiveInt]] instances.
+    */
   object PositiveInt:
 
-    /**
-     * Smart constructor for unknown integers at compile time.
-     *
-     * @param intCandidate
-     *   An unknown integer.
-     * @return
-     *   An Either with a Right PositiveInt or a Left IllegalStateException.
-     */
+    /** Smart constructor for unknown integers at compile time.
+      *
+      * @param intCandidate
+      *   An unknown integer.
+      * @return
+      *   An Either with a Right PositiveInt or a Left IllegalStateException.
+      */
     def from(intCandidate: Int): Either[Throwable, PositiveInt] =
-      if intCandidate < 0
-      then Left(new IllegalStateException(s"The provided int $intCandidate is not positive."))
+      if intCandidate < 0 then Left(new IllegalStateException(s"The provided int $intCandidate is not positive."))
       else Right(intCandidate)
 
-    /**
-     * Smart constructor for known integers at compile time. Use this method and not [[from]] when working with fixed values (''magic numbers'').
-     *
-     * @param int
-     *   A known integer.
-     * @return
-     *   A valid PositiveInt or a compiler error.
-     * @see
-     *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
-     */
+    /** Smart constructor for known integers at compile time. Use this method and not [[from]] when working with fixed
+      * values (''magic numbers'').
+      *
+      * @param int
+      *   A known integer.
+      * @return
+      *   A valid PositiveInt or a compiler error.
+      * @see
+      *   More info at [[https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html]]
+      */
     inline def apply(int: Int): PositiveInt =
-      inline if constValue[int.type >= 0]
-      then int
-      else error(codeOf(int) + " is negative. Int must be positive.")
+      inline if constValue[int.type >= 0] then int else error(codeOf(int) + " is negative. Int must be positive.")
 
-    /**
-     * When the compiler expects a value of type Int but it finds a value of type PositiveInt, it executes this.
-     *
-     * @return
-     *   Value of type PositiveInt as type Int.
-     */
+    /** When the compiler expects a value of type Int but it finds a value of type PositiveInt, it executes this.
+      *
+      * @return
+      *   Value of type PositiveInt as type Int.
+      */
     given Conversion[PositiveInt, Int] with
       override def apply(x: PositiveInt): Int = x
+
+  end PositiveInt
+
+end refinedTypes

--- a/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
+++ b/02-c-api/src/main/scala/com/fortyseven/common/configuration/refinedTypes.scala
@@ -16,9 +16,11 @@
 
 package com.fortyseven.common.configuration
 
+import scala.compiletime.codeOf
+import scala.compiletime.constValue
+import scala.compiletime.error
 import scala.compiletime.ops.int.*
 import scala.compiletime.ops.string.Matches
-import scala.compiletime.{codeOf, constValue, error}
 import scala.util.Try
 
 /**

--- a/02-c-api/src/test/scala/com/fortyseven/common/configuration/refinedTypesTest.scala
+++ b/02-c-api/src/test/scala/com/fortyseven/common/configuration/refinedTypesTest.scala
@@ -16,7 +16,11 @@
 
 package com.fortyseven.common.configuration
 
-import com.fortyseven.common.configuration.refinedTypes.{KafkaAutoOffsetReset, KafkaCompressionType, NonEmptyString, PositiveInt}
+import com.fortyseven.common.configuration.refinedTypes.KafkaAutoOffsetReset
+import com.fortyseven.common.configuration.refinedTypes.KafkaCompressionType
+import com.fortyseven.common.configuration.refinedTypes.NonEmptyString
+import com.fortyseven.common.configuration.refinedTypes.PositiveInt
+
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll

--- a/02-c-api/src/test/scala/com/fortyseven/common/configuration/refinedTypesTest.scala
+++ b/02-c-api/src/test/scala/com/fortyseven/common/configuration/refinedTypesTest.scala
@@ -32,16 +32,16 @@ class refinedTypesTest extends ScalaCheckSuite:
       KafkaCompressionType.from(kct).isRight
 
   property("An invalid KafkaCompressionType should return Left"):
-    forAll(Gen.alphaStr.suchThat(randomString => !KafkaCompressionType.values.map(_.toString).contains(randomString))): kct =>
-      KafkaCompressionType.from(kct).isLeft
+    forAll(Gen.alphaStr.suchThat(randomString => !KafkaCompressionType.values.map(_.toString).contains(randomString))):
+      kct => KafkaCompressionType.from(kct).isLeft
 
   property("A valid value of KafkaAutoOffsetReset should return Right"):
     forAll(Gen.oneOf(KafkaAutoOffsetReset.values.toIndexedSeq).map(_.toString)): kct =>
       KafkaAutoOffsetReset.from(kct).isRight
 
   property("An invalid KafkaAutoOffsetReset should return Left"):
-    forAll(Gen.alphaStr.suchThat(randomString => !KafkaAutoOffsetReset.values.map(_.toString).contains(randomString))): kct =>
-      KafkaAutoOffsetReset.from(kct).isLeft
+    forAll(Gen.alphaStr.suchThat(randomString => !KafkaAutoOffsetReset.values.map(_.toString).contains(randomString))):
+      kct => KafkaAutoOffsetReset.from(kct).isLeft
 
   property("Any String that is empty or has only spaces should return Left"):
     forAll(Gen.oneOf(IndexedSeq("", " ", "  ", "    "))): string =>
@@ -58,3 +58,5 @@ class refinedTypesTest extends ScalaCheckSuite:
   property("Any Integer that is zero or positive should return a valid PositiveInt"):
     forAll(Gen.posNum[Int]): positive =>
       PositiveInt.from(positive).isRight
+
+end refinedTypesTest

--- a/02-o-api/src/main/scala/com/fortyseven/output/api/FlinkProcessorAPI.scala
+++ b/02-o-api/src/main/scala/com/fortyseven/output/api/FlinkProcessorAPI.scala
@@ -18,15 +18,13 @@ package com.fortyseven.output.api
 
 import com.fortyseven.common.configuration.FlinkProcessorConfigurationI
 
-/**
- * @tparam F
- *   The effect in with Flink is executed.
- */
+/** @tparam F
+  *   The effect in with Flink is executed.
+  */
 trait FlinkProcessorAPI[F[_]]:
-  /**
-   * @param config
-   *   An instance of a class that extends [[FlinkConfiguration]].
-   * @return
-   *   It executes the effects of the Flink Processor and returns Unit.
-   */
+  /** @param config
+    *   An instance of a class that extends [[FlinkConfiguration]].
+    * @return
+    *   It executes the effects of the Flink Processor and returns Unit.
+    */
   def process[Configuration <: FlinkProcessorConfigurationI](config: Configuration): F[Unit]

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/datagenerator/DataGeneratorConfiguration.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/datagenerator/DataGeneratorConfiguration.scala
@@ -21,21 +21,20 @@ import scala.concurrent.duration.FiniteDuration
 import com.fortyseven.common.configuration.*
 import com.fortyseven.common.configuration.refinedTypes.*
 
-private[datagenerator] final case class DataGeneratorConfiguration(
+final private[datagenerator] case class DataGeneratorConfiguration(
     kafka: DataGeneratorKafkaConfiguration,
     schemaRegistry: DataGeneratorSchemaRegistryConfiguration
 ) extends DataGeneratorConfigurationI
 
-private[datagenerator] final case class DataGeneratorKafkaConfiguration(
+final private[datagenerator] case class DataGeneratorKafkaConfiguration(
     broker: DataGeneratorBrokerConfiguration,
     producer: DataGeneratorProducerConfiguration
 ) extends DataGeneratorKafkaConfigurationI
 
-private[datagenerator] final case class DataGeneratorBrokerConfiguration(
-    bootstrapServers: NonEmptyString
-) extends DataGeneratorBrokerConfigurationI
+final private[datagenerator] case class DataGeneratorBrokerConfiguration(bootstrapServers: NonEmptyString)
+    extends DataGeneratorBrokerConfigurationI
 
-private[datagenerator] final case class DataGeneratorProducerConfiguration(
+final private[datagenerator] case class DataGeneratorProducerConfiguration(
     topicName: NonEmptyString,
     valueSerializerClass: NonEmptyString,
     maxConcurrent: PositiveInt,
@@ -44,6 +43,5 @@ private[datagenerator] final case class DataGeneratorProducerConfiguration(
     commitBatchWithinTime: FiniteDuration
 ) extends DataGeneratorProducerConfigurationI
 
-private[datagenerator] final case class DataGeneratorSchemaRegistryConfiguration(
-    schemaRegistryUrl: NonEmptyString
-) extends DataGeneratorSchemaRegistryConfigurationI
+final private[datagenerator] case class DataGeneratorSchemaRegistryConfiguration(schemaRegistryUrl: NonEmptyString)
+    extends DataGeneratorSchemaRegistryConfigurationI

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/datagenerator/DataGeneratorConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/datagenerator/DataGeneratorConfigurationLoader.scala
@@ -16,14 +16,15 @@
 
 package com.fortyseven.cirisconfiguration.datagenerator
 
-import scala.concurrent.duration.*
-
 import cats.effect.kernel.Async
 
-import ciris.*
+import scala.concurrent.duration.*
+
 import com.fortyseven.cirisconfiguration.decoders.given
 import com.fortyseven.common.api.ConfigurationAPI
 import com.fortyseven.common.configuration.refinedTypes.*
+
+import ciris.*
 
 final class DataGeneratorConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F, DataGeneratorConfiguration]:
 

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/datagenerator/DataGeneratorConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/datagenerator/DataGeneratorConfigurationLoader.scala
@@ -30,19 +30,18 @@ final class DataGeneratorConfigurationLoader[F[_]: Async] extends ConfigurationA
 
   private def defaultConfig(): ConfigValue[Effect, DataGeneratorConfiguration] =
     for
-      kafkaBrokerBoostrapServers         <- default("localhost:9092").as[NonEmptyString]
-      kafkaProducerTopicName             <- default("data-generator").as[NonEmptyString]
-      kafkaProducerValueSerializerClass  <- default("io.confluent.kafka.serializers.KafkaAvroSerializer").as[NonEmptyString]
-      kafkaProducerMaxConcurrent         <- default(Int.MaxValue).as[PositiveInt]
-      kafkaProducerCompressionType       <- default(KafkaCompressionType.lz4).as[KafkaCompressionType]
+      kafkaBrokerBoostrapServers <- default("localhost:9092").as[NonEmptyString]
+      kafkaProducerTopicName <- default("data-generator").as[NonEmptyString]
+      kafkaProducerValueSerializerClass <- default("io.confluent.kafka.serializers.KafkaAvroSerializer")
+        .as[NonEmptyString]
+      kafkaProducerMaxConcurrent <- default(Int.MaxValue).as[PositiveInt]
+      kafkaProducerCompressionType <- default(KafkaCompressionType.lz4).as[KafkaCompressionType]
       kafkaProducerCommitBatchWithinSize <- default(10).as[PositiveInt]
       kafkaProducerCommitBatchWithinTime <- default(15.seconds).as[FiniteDuration]
-      schemaRegistryUrl                  <- default("http://localhost:8081").as[NonEmptyString]
+      schemaRegistryUrl <- default("http://localhost:8081").as[NonEmptyString]
     yield DataGeneratorConfiguration(
       kafka = DataGeneratorKafkaConfiguration(
-        broker = DataGeneratorBrokerConfiguration(
-          bootstrapServers = kafkaBrokerBoostrapServers
-        ),
+        broker = DataGeneratorBrokerConfiguration(bootstrapServers = kafkaBrokerBoostrapServers),
         producer = DataGeneratorProducerConfiguration(
           topicName = kafkaProducerTopicName,
           valueSerializerClass = kafkaProducerValueSerializerClass,
@@ -52,9 +51,9 @@ final class DataGeneratorConfigurationLoader[F[_]: Async] extends ConfigurationA
           commitBatchWithinTime = kafkaProducerCommitBatchWithinTime
         )
       ),
-      schemaRegistry = DataGeneratorSchemaRegistryConfiguration(
-        schemaRegistryUrl = schemaRegistryUrl
-      )
+      schemaRegistry = DataGeneratorSchemaRegistryConfiguration(schemaRegistryUrl = schemaRegistryUrl)
     )
 
   override def load(): F[DataGeneratorConfiguration] = defaultConfig().load[F]
+
+end DataGeneratorConfigurationLoader

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/decoders.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/decoders.scala
@@ -16,8 +16,11 @@
 
 package com.fortyseven.cirisconfiguration
 
-import ciris.{ConfigDecoder, ConfigError}
-import com.fortyseven.common.configuration.refinedTypes.{NonEmptyString, PositiveInt}
+import com.fortyseven.common.configuration.refinedTypes.NonEmptyString
+import com.fortyseven.common.configuration.refinedTypes.PositiveInt
+
+import ciris.ConfigDecoder
+import ciris.ConfigError
 
 object decoders:
 

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/decoders.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/decoders.scala
@@ -24,18 +24,18 @@ import ciris.ConfigError
 
 object decoders:
 
-  given ConfigDecoder[Int, PositiveInt] =
-    ConfigDecoder[Int, Int].mapEither { (None, i) =>
-      PositiveInt.from(i) match
-        case Right(value) => Right(value)
-        case Left(throwable) =>
-          Left(ConfigError.apply(s"Failing at decoding the value $i. Error: ${throwable.getMessage}"))
-    }
+  given ConfigDecoder[Int, PositiveInt] = ConfigDecoder[Int, Int].mapEither { (None, i) =>
+    PositiveInt.from(i) match
+      case Right(value) => Right(value)
+      case Left(throwable) =>
+        Left(ConfigError.apply(s"Failing at decoding the value $i. Error: ${throwable.getMessage}"))
+  }
 
-  given ConfigDecoder[String, NonEmptyString] =
-    ConfigDecoder[String, String].mapEither { (None, s) =>
-      NonEmptyString.from(s) match
-        case Right(value) => Right(value)
-        case Left(throwable) =>
-          Left(ConfigError.apply(s"Failing at decoding the value $s. Error: ${throwable.getMessage}"))
-    }
+  given ConfigDecoder[String, NonEmptyString] = ConfigDecoder[String, String].mapEither { (None, s) =>
+    NonEmptyString.from(s) match
+      case Right(value) => Right(value)
+      case Left(throwable) =>
+        Left(ConfigError.apply(s"Failing at decoding the value $s. Error: ${throwable.getMessage}"))
+  }
+
+end decoders

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfiguration.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfiguration.scala
@@ -26,33 +26,31 @@ import com.fortyseven.common.configuration.FlinkProcessorProducerConfigurationI
 import com.fortyseven.common.configuration.FlinkProcessorSchemaRegistryConfigurationI
 import com.fortyseven.common.configuration.refinedTypes.*
 
-private[flink] final case class FlinkProcessorConfiguration(
+final private[flink] case class FlinkProcessorConfiguration(
     kafka: KafkaConfiguration,
     schemaRegistry: SchemaRegistryConfiguration
 ) extends FlinkProcessorConfigurationI
 
-private[flink] final case class SchemaRegistryConfiguration(
-    schemaRegistryUrl: NonEmptyString
-) extends FlinkProcessorSchemaRegistryConfigurationI
+final private[flink] case class SchemaRegistryConfiguration(schemaRegistryUrl: NonEmptyString)
+    extends FlinkProcessorSchemaRegistryConfigurationI
 
-private[flink] final case class KafkaConfiguration(
+final private[flink] case class KafkaConfiguration(
     broker: BrokerConfiguration,
     consumer: Option[ConsumerConfiguration],
     producer: Option[ProducerConfiguration]
 ) extends FlinkProcessorKafkaConfigurationI
 
-private[flink] final case class BrokerConfiguration(
-    brokerAddress: NonEmptyString
-) extends FlinkProcessorBrokerConfigurationI
+final private[flink] case class BrokerConfiguration(brokerAddress: NonEmptyString)
+    extends FlinkProcessorBrokerConfigurationI
 
-private[flink] final case class ConsumerConfiguration(
+final private[flink] case class ConsumerConfiguration(
     topicName: NonEmptyString,
     autoOffsetReset: KafkaAutoOffsetReset,
     groupId: NonEmptyString,
     maxConcurrent: PositiveInt
 ) extends FlinkProcessorConsumerConfigurationI
 
-private[flink] final case class ProducerConfiguration(
+final private[flink] case class ProducerConfiguration(
     topicName: NonEmptyString,
     valueSerializerClass: NonEmptyString,
     maxConcurrent: PositiveInt,

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfiguration.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfiguration.scala
@@ -18,15 +18,13 @@ package com.fortyseven.cirisconfiguration.flink
 
 import scala.concurrent.duration.FiniteDuration
 
+import com.fortyseven.common.configuration.FlinkProcessorBrokerConfigurationI
+import com.fortyseven.common.configuration.FlinkProcessorConfigurationI
+import com.fortyseven.common.configuration.FlinkProcessorConsumerConfigurationI
+import com.fortyseven.common.configuration.FlinkProcessorKafkaConfigurationI
+import com.fortyseven.common.configuration.FlinkProcessorProducerConfigurationI
+import com.fortyseven.common.configuration.FlinkProcessorSchemaRegistryConfigurationI
 import com.fortyseven.common.configuration.refinedTypes.*
-import com.fortyseven.common.configuration.{
-  FlinkProcessorBrokerConfigurationI,
-  FlinkProcessorConfigurationI,
-  FlinkProcessorConsumerConfigurationI,
-  FlinkProcessorKafkaConfigurationI,
-  FlinkProcessorProducerConfigurationI,
-  FlinkProcessorSchemaRegistryConfigurationI
-}
 
 private[flink] final case class FlinkProcessorConfiguration(
     kafka: KafkaConfiguration,

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
@@ -16,14 +16,15 @@
 
 package com.fortyseven.cirisconfiguration.flink
 
-import scala.concurrent.duration.*
-
 import cats.effect.kernel.Async
 
-import ciris.*
+import scala.concurrent.duration.*
+
 import com.fortyseven.cirisconfiguration.decoders.given
 import com.fortyseven.common.api.ConfigurationAPI
 import com.fortyseven.common.configuration.refinedTypes.*
+
+import ciris.*
 
 class FlinkProcessorConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F, FlinkProcessorConfiguration]:
 

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/flink/FlinkProcessorConfigurationLoader.scala
@@ -30,40 +30,40 @@ class FlinkProcessorConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F,
 
   private def defaultConfig(): ConfigValue[Effect, FlinkProcessorConfiguration] =
     for
-      kafkaBrokerAddress                 <- default("localhost:9092").as[NonEmptyString]
-      kafkaConsumerTopicName             <- default("input-topic-pp").as[NonEmptyString]
-      kafkaConsumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
-      kafkaConsumerGroupId               <- default("groupId").as[NonEmptyString]
-      kafkaConsumerMaxConcurrent         <- default(25).as[PositiveInt]
-      kafkaProducerTopicName             <- default("output-topic").as[NonEmptyString]
-      kafkaProducerValueSerializerClass  <- default("io.confluent.kafka.serializers.KafkaAvroSerializer").as[NonEmptyString]
-      kafkaProducerMaxConcurrent         <- default(Int.MaxValue).as[PositiveInt]
-      kafkaProducerCompressionType       <- default(KafkaCompressionType.lz4).as[KafkaCompressionType]
+      kafkaBrokerAddress <- default("localhost:9092").as[NonEmptyString]
+      kafkaConsumerTopicName <- default("input-topic-pp").as[NonEmptyString]
+      kafkaConsumerAutoOffsetReset <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
+      kafkaConsumerGroupId <- default("groupId").as[NonEmptyString]
+      kafkaConsumerMaxConcurrent <- default(25).as[PositiveInt]
+      kafkaProducerTopicName <- default("output-topic").as[NonEmptyString]
+      kafkaProducerValueSerializerClass <- default("io.confluent.kafka.serializers.KafkaAvroSerializer")
+        .as[NonEmptyString]
+      kafkaProducerMaxConcurrent <- default(Int.MaxValue).as[PositiveInt]
+      kafkaProducerCompressionType <- default(KafkaCompressionType.lz4).as[KafkaCompressionType]
       kafkaProducerCommitBatchWithinSize <- default(10).as[PositiveInt]
       kafkaProducerCommitBatchWithinTime <- default(15.seconds).as[FiniteDuration]
-      schemaRegistryUrl                  <- default("http://localhost:8081").as[NonEmptyString]
+      schemaRegistryUrl <- default("http://localhost:8081").as[NonEmptyString]
     yield FlinkProcessorConfiguration(
       KafkaConfiguration(
         broker = BrokerConfiguration(kafkaBrokerAddress),
-        consumer = Some(
-          ConsumerConfiguration(topicName = kafkaConsumerTopicName,
-                                autoOffsetReset = kafkaConsumerAutoOffsetReset,
-                                groupId = kafkaConsumerGroupId,
-                                maxConcurrent = kafkaConsumerMaxConcurrent
-          )
-        ),
-        producer = Some(
-          ProducerConfiguration(
-            topicName = kafkaProducerTopicName,
-            valueSerializerClass = kafkaProducerValueSerializerClass,
-            maxConcurrent = kafkaProducerMaxConcurrent,
-            compressionType = kafkaProducerCompressionType,
-            commitBatchWithinSize = kafkaProducerCommitBatchWithinSize,
-            commitBatchWithinTime = kafkaProducerCommitBatchWithinTime
-          )
-        )
+        consumer = Some(ConsumerConfiguration(
+          topicName = kafkaConsumerTopicName,
+          autoOffsetReset = kafkaConsumerAutoOffsetReset,
+          groupId = kafkaConsumerGroupId,
+          maxConcurrent = kafkaConsumerMaxConcurrent
+        )),
+        producer = Some(ProducerConfiguration(
+          topicName = kafkaProducerTopicName,
+          valueSerializerClass = kafkaProducerValueSerializerClass,
+          maxConcurrent = kafkaProducerMaxConcurrent,
+          compressionType = kafkaProducerCompressionType,
+          commitBatchWithinSize = kafkaProducerCommitBatchWithinSize,
+          commitBatchWithinTime = kafkaProducerCommitBatchWithinTime
+        ))
       ),
       SchemaRegistryConfiguration(schemaRegistryUrl)
     )
 
   override def load(): F[FlinkProcessorConfiguration] = defaultConfig().load[F]
+
+end FlinkProcessorConfigurationLoader

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfiguration.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfiguration.scala
@@ -21,22 +21,23 @@ import scala.concurrent.duration.FiniteDuration
 import com.fortyseven.common.configuration.*
 import com.fortyseven.common.configuration.refinedTypes.*
 
-private[kafkaconsumer] final case class KafkaConsumerConfiguration(
+final private[kafkaconsumer] case class KafkaConsumerConfiguration(
     broker: BrokerConfiguration,
     consumer: Option[ConsumerConfiguration],
     producer: Option[ProducerConfiguration]
 ) extends KafkaConsumerConfigurationI
 
-private[kafkaconsumer] final case class BrokerConfiguration(brokerAddress: NonEmptyString) extends KafkaConsumerBrokerConfigurationI
+final private[kafkaconsumer] case class BrokerConfiguration(brokerAddress: NonEmptyString)
+    extends KafkaConsumerBrokerConfigurationI
 
-private[kafkaconsumer] final case class ConsumerConfiguration(
+final private[kafkaconsumer] case class ConsumerConfiguration(
     topicName: NonEmptyString,
     autoOffsetReset: KafkaAutoOffsetReset,
     groupId: NonEmptyString,
     maxConcurrent: PositiveInt
 ) extends KafkaConsumerConsumerConfigurationI
 
-private[kafkaconsumer] final case class ProducerConfiguration(
+final private[kafkaconsumer] case class ProducerConfiguration(
     topicName: NonEmptyString,
     valueSerializerClass: NonEmptyString,
     maxConcurrent: PositiveInt,

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
@@ -30,37 +30,35 @@ final class KafkaConsumerConfigurationLoader[F[_]: Async] extends ConfigurationA
 
   private def defaultConfig(): ConfigValue[Effect, KafkaConsumerConfiguration] =
     for
-      brokerAddress                 <- default("localhost:9092").as[NonEmptyString]
-      consumerTopicName             <- default("data-generator").as[NonEmptyString]
-      consumerAutoOffsetReset       <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
-      consumerGroupId               <- default("groupId").as[NonEmptyString]
-      consumerMaxConcurrent         <- default(25).as[PositiveInt]
-      producerTopicName             <- default("input-topic").as[NonEmptyString]
-      producerValueSerializerClass  <- default("io.confluent.kafka.serializers.KafkaAvroSerializer").as[NonEmptyString]
-      producerMaxConcurrent         <- default(Int.MaxValue).as[PositiveInt]
-      producerCompressionType       <- default(KafkaCompressionType.lz4).as[KafkaCompressionType]
+      brokerAddress <- default("localhost:9092").as[NonEmptyString]
+      consumerTopicName <- default("data-generator").as[NonEmptyString]
+      consumerAutoOffsetReset <- default(KafkaAutoOffsetReset.earliest).as[KafkaAutoOffsetReset]
+      consumerGroupId <- default("groupId").as[NonEmptyString]
+      consumerMaxConcurrent <- default(25).as[PositiveInt]
+      producerTopicName <- default("input-topic").as[NonEmptyString]
+      producerValueSerializerClass <- default("io.confluent.kafka.serializers.KafkaAvroSerializer").as[NonEmptyString]
+      producerMaxConcurrent <- default(Int.MaxValue).as[PositiveInt]
+      producerCompressionType <- default(KafkaCompressionType.lz4).as[KafkaCompressionType]
       producerCommitBatchWithinSize <- default(10).as[PositiveInt]
       producerCommitBatchWithinTime <- default(15.seconds).as[FiniteDuration]
     yield KafkaConsumerConfiguration(
       broker = BrokerConfiguration(brokerAddress),
-      consumer = Some(
-        ConsumerConfiguration(
-          topicName = consumerTopicName,
-          autoOffsetReset = consumerAutoOffsetReset,
-          groupId = consumerGroupId,
-          maxConcurrent = consumerMaxConcurrent
-        )
-      ),
-      producer = Some(
-        ProducerConfiguration(
-          topicName = producerTopicName,
-          valueSerializerClass = producerValueSerializerClass,
-          maxConcurrent = producerMaxConcurrent,
-          compressionType = producerCompressionType,
-          commitBatchWithinSize = producerCommitBatchWithinSize,
-          commitBatchWithinTime = producerCommitBatchWithinTime
-        )
-      )
+      consumer = Some(ConsumerConfiguration(
+        topicName = consumerTopicName,
+        autoOffsetReset = consumerAutoOffsetReset,
+        groupId = consumerGroupId,
+        maxConcurrent = consumerMaxConcurrent
+      )),
+      producer = Some(ProducerConfiguration(
+        topicName = producerTopicName,
+        valueSerializerClass = producerValueSerializerClass,
+        maxConcurrent = producerMaxConcurrent,
+        compressionType = producerCompressionType,
+        commitBatchWithinSize = producerCommitBatchWithinSize,
+        commitBatchWithinTime = producerCommitBatchWithinTime
+      ))
     )
 
   override def load(): F[KafkaConsumerConfiguration] = defaultConfig().load[F]
+
+end KafkaConsumerConfigurationLoader

--- a/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
+++ b/03-c-config-ciris/src/main/scala/com/fortyseven/cirisconfiguration/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
@@ -16,14 +16,15 @@
 
 package com.fortyseven.cirisconfiguration.kafkaconsumer
 
-import scala.concurrent.duration.*
-
 import cats.effect.kernel.Async
 
-import ciris.*
+import scala.concurrent.duration.*
+
 import com.fortyseven.cirisconfiguration.decoders.given
 import com.fortyseven.common.api.ConfigurationAPI
 import com.fortyseven.common.configuration.refinedTypes.*
+
+import ciris.*
 
 final class KafkaConsumerConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F, KafkaConsumerConfiguration]:
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfiguration.scala
@@ -25,7 +25,7 @@ import com.fortyseven.pureconfig.refinedTypesGivens.given
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.derived
 
-private[datagenerator] final case class DataGeneratorConfiguration(
+final private[datagenerator] case class DataGeneratorConfiguration(
     kafka: DataGeneratorKafkaConfiguration,
     schemaRegistry: DataGeneratorSchemaRegistryConfiguration
 ) extends DataGeneratorConfigurationI
@@ -33,7 +33,7 @@ private[datagenerator] final case class DataGeneratorConfiguration(
 object DataGeneratorConfiguration:
   given ConfigReader[DataGeneratorConfiguration] = ConfigReader.derived[DataGeneratorConfiguration]
 
-private[datagenerator] final case class DataGeneratorKafkaConfiguration(
+final private[datagenerator] case class DataGeneratorKafkaConfiguration(
     broker: DataGeneratorBrokerConfiguration,
     producer: DataGeneratorProducerConfiguration
 ) extends DataGeneratorKafkaConfigurationI
@@ -41,14 +41,13 @@ private[datagenerator] final case class DataGeneratorKafkaConfiguration(
 object DataGeneratorKafkaConfiguration:
   given ConfigReader[DataGeneratorKafkaConfiguration] = ConfigReader.derived[DataGeneratorKafkaConfiguration]
 
-private[datagenerator] final case class DataGeneratorBrokerConfiguration(
-    bootstrapServers: NonEmptyString
-) extends DataGeneratorBrokerConfigurationI
+final private[datagenerator] case class DataGeneratorBrokerConfiguration(bootstrapServers: NonEmptyString)
+    extends DataGeneratorBrokerConfigurationI
 
 object DataGeneratorBrokerConfiguration:
   given ConfigReader[DataGeneratorBrokerConfiguration] = ConfigReader.derived[DataGeneratorBrokerConfiguration]
 
-private[datagenerator] final case class DataGeneratorProducerConfiguration(
+final private[datagenerator] case class DataGeneratorProducerConfiguration(
     topicName: NonEmptyString,
     valueSerializerClass: NonEmptyString,
     maxConcurrent: PositiveInt,
@@ -60,9 +59,10 @@ private[datagenerator] final case class DataGeneratorProducerConfiguration(
 object DataGeneratorProducerConfiguration:
   given ConfigReader[DataGeneratorProducerConfiguration] = ConfigReader.derived[DataGeneratorProducerConfiguration]
 
-private[datagenerator] final case class DataGeneratorSchemaRegistryConfiguration(
-    schemaRegistryUrl: NonEmptyString
-) extends DataGeneratorSchemaRegistryConfigurationI
+final private[datagenerator] case class DataGeneratorSchemaRegistryConfiguration(schemaRegistryUrl: NonEmptyString)
+    extends DataGeneratorSchemaRegistryConfigurationI
 
 object DataGeneratorSchemaRegistryConfiguration:
-  given ConfigReader[DataGeneratorSchemaRegistryConfiguration] = ConfigReader.derived[DataGeneratorSchemaRegistryConfiguration]
+
+  given ConfigReader[DataGeneratorSchemaRegistryConfiguration] = ConfigReader
+    .derived[DataGeneratorSchemaRegistryConfiguration]

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfiguration.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration.FiniteDuration
 import com.fortyseven.common.configuration.*
 import com.fortyseven.common.configuration.refinedTypes.*
 import com.fortyseven.pureconfig.refinedTypesGivens.given
+
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.derived
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfigurationLoader.scala
@@ -19,6 +19,7 @@ package com.fortyseven.pureconfig.datagenerator
 import cats.effect.kernel.Async
 
 import com.fortyseven.common.api.ConfigurationAPI
+
 import pureconfig.ConfigSource
 import pureconfig.module.catseffect.syntax.*
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/datagenerator/DataGeneratorConfigurationLoader.scala
@@ -25,11 +25,13 @@ import pureconfig.module.catseffect.syntax.*
 
 final class DataGeneratorConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F, DataGeneratorConfiguration]:
 
-  /**
-   * @return
-   *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the method is mappable or flatMappable
-   *   since it is wrapped into an effect. Thus, you can use it in a for-comprehension. If the value of the configuration fails to be loaded, the
-   *   effect will handle the error gracefully.
-   */
-  override def load(): F[DataGeneratorConfiguration] =
-    ConfigSource.default.at("data-generator").loadF[F, DataGeneratorConfiguration]()
+  /** @return
+    *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the
+    *   method is mappable or flatMappable since it is wrapped into an effect. Thus, you can use it in a
+    *   for-comprehension. If the value of the configuration fails to be loaded, the effect will handle the error
+    *   gracefully.
+    */
+  override def load(): F[DataGeneratorConfiguration] = ConfigSource
+    .default
+    .at("data-generator")
+    .loadF[F, DataGeneratorConfiguration]()

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfiguration.scala
@@ -25,7 +25,7 @@ import com.fortyseven.pureconfig.refinedTypesGivens.given
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.derived
 
-private[flink] final case class FlinkProcessorConfiguration(
+final private[flink] case class FlinkProcessorConfiguration(
     kafka: KafkaConfiguration,
     schemaRegistry: SchemaRegistryConfiguration
 ) extends FlinkProcessorConfigurationI
@@ -33,7 +33,7 @@ private[flink] final case class FlinkProcessorConfiguration(
 object FlinkProcessorConfiguration:
   given ConfigReader[FlinkProcessorConfiguration] = ConfigReader.derived[FlinkProcessorConfiguration]
 
-private[flink] final case class KafkaConfiguration(
+final private[flink] case class KafkaConfiguration(
     broker: BrokerConfiguration,
     consumer: Option[ConsumerConfiguration],
     producer: Option[ProducerConfiguration]
@@ -42,14 +42,13 @@ private[flink] final case class KafkaConfiguration(
 object KafkaConfiguration:
   given ConfigReader[KafkaConfiguration] = ConfigReader.derived[KafkaConfiguration]
 
-private[flink] final case class BrokerConfiguration(
-    brokerAddress: NonEmptyString
-) extends FlinkProcessorBrokerConfigurationI
+final private[flink] case class BrokerConfiguration(brokerAddress: NonEmptyString)
+    extends FlinkProcessorBrokerConfigurationI
 
 object BrokerConfiguration:
   given ConfigReader[BrokerConfiguration] = ConfigReader.derived[BrokerConfiguration]
 
-private[flink] final case class ConsumerConfiguration(
+final private[flink] case class ConsumerConfiguration(
     topicName: NonEmptyString,
     autoOffsetReset: KafkaAutoOffsetReset,
     groupId: NonEmptyString,
@@ -59,7 +58,7 @@ private[flink] final case class ConsumerConfiguration(
 object ConsumerConfiguration:
   given ConfigReader[ConsumerConfiguration] = ConfigReader.derived[ConsumerConfiguration]
 
-private[flink] final case class ProducerConfiguration(
+final private[flink] case class ProducerConfiguration(
     topicName: NonEmptyString,
     valueSerializerClass: NonEmptyString,
     maxConcurrent: PositiveInt,
@@ -71,9 +70,8 @@ private[flink] final case class ProducerConfiguration(
 object ProducerConfiguration:
   given ConfigReader[ProducerConfiguration] = ConfigReader.derived[ProducerConfiguration]
 
-private[flink] final case class SchemaRegistryConfiguration(
-    schemaRegistryUrl: NonEmptyString
-) extends FlinkProcessorSchemaRegistryConfigurationI
+final private[flink] case class SchemaRegistryConfiguration(schemaRegistryUrl: NonEmptyString)
+    extends FlinkProcessorSchemaRegistryConfigurationI
 
 object SchemaRegistryConfiguration:
   given ConfigReader[SchemaRegistryConfiguration] = ConfigReader.derived[SchemaRegistryConfiguration]

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfiguration.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration.FiniteDuration
 import com.fortyseven.common.configuration.*
 import com.fortyseven.common.configuration.refinedTypes.*
 import com.fortyseven.pureconfig.refinedTypesGivens.given
+
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.derived
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfigurationLoader.scala
@@ -19,6 +19,7 @@ package com.fortyseven.pureconfig.flink
 import cats.effect.kernel.Async
 
 import com.fortyseven.common.api.ConfigurationAPI
+
 import pureconfig.ConfigSource
 import pureconfig.module.catseffect.syntax.*
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/flink/FlinkProcessorConfigurationLoader.scala
@@ -25,11 +25,13 @@ import pureconfig.module.catseffect.syntax.*
 
 final class FlinkProcessorConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F, FlinkProcessorConfiguration]:
 
-  /**
-   * @return
-   *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the method is mappable or flatMappable
-   *   since it is wrapped into an effect. Thus, you can use it in a for-comprehension. If the value of the configuration fails to be loaded, the
-   *   effect will handle the error gracefully.
-   */
-  override def load(): F[FlinkProcessorConfiguration] =
-    ConfigSource.default.at("processor-flink").loadF[F, FlinkProcessorConfiguration]()
+  /** @return
+    *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the
+    *   method is mappable or flatMappable since it is wrapped into an effect. Thus, you can use it in a
+    *   for-comprehension. If the value of the configuration fails to be loaded, the effect will handle the error
+    *   gracefully.
+    */
+  override def load(): F[FlinkProcessorConfiguration] = ConfigSource
+    .default
+    .at("processor-flink")
+    .loadF[F, FlinkProcessorConfiguration]()

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfiguration.scala
@@ -45,7 +45,8 @@ private[kafkaconsumer] case class ConsumerConfiguration(
 object ConsumerConfiguration:
   given ConfigReader[ConsumerConfiguration] = ConfigReader.derived[ConsumerConfiguration]
 
-private[kafkaconsumer] case class BrokerConfiguration(brokerAddress: NonEmptyString) extends KafkaConsumerBrokerConfigurationI
+private[kafkaconsumer] case class BrokerConfiguration(brokerAddress: NonEmptyString)
+    extends KafkaConsumerBrokerConfigurationI
 
 object BrokerConfiguration:
   given ConfigReader[BrokerConfiguration] = ConfigReader.derived[BrokerConfiguration]

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfiguration.scala
@@ -22,6 +22,7 @@ import com.fortyseven.common.configuration.*
 import com.fortyseven.common.configuration.refinedTypes.*
 import com.fortyseven.pureconfig.*
 import com.fortyseven.pureconfig.refinedTypesGivens.given
+
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.derived
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
@@ -25,11 +25,13 @@ import pureconfig.module.catseffect.syntax.*
 
 final class KafkaConsumerConfigurationLoader[F[_]: Async] extends ConfigurationAPI[F, KafkaConsumerConfiguration]:
 
-  /**
-   * @return
-   *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the method is mappable or flatMappable
-   *   since it is wrapped into an effect. Thus, you can use it in a for-comprehension. If the value of the configuration fails to be loaded, the
-   *   effect will handle the error gracefully.
-   */
-  override def load(): F[KafkaConsumerConfiguration] =
-    ConfigSource.default.at("kafka-consumer").loadF[F, KafkaConsumerConfiguration]()
+  /** @return
+    *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the
+    *   method is mappable or flatMappable since it is wrapped into an effect. Thus, you can use it in a
+    *   for-comprehension. If the value of the configuration fails to be loaded, the effect will handle the error
+    *   gracefully.
+    */
+  override def load(): F[KafkaConsumerConfiguration] = ConfigSource
+    .default
+    .at("kafka-consumer")
+    .loadF[F, KafkaConsumerConfiguration]()

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/kafkaconsumer/KafkaConsumerConfigurationLoader.scala
@@ -19,6 +19,7 @@ package com.fortyseven.pureconfig.kafkaconsumer
 import cats.effect.kernel.Async
 
 import com.fortyseven.common.api.ConfigurationAPI
+
 import pureconfig.ConfigSource
 import pureconfig.module.catseffect.syntax.*
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/refinedTypesGivens.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/refinedTypesGivens.scala
@@ -20,6 +20,7 @@ import cats.syntax.all.*
 
 import com.fortyseven.common.configuration.*
 import com.fortyseven.common.configuration.refinedTypes.*
+
 import pureconfig.ConfigReader
 import pureconfig.error.ExceptionThrown
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/refinedTypesGivens.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/refinedTypesGivens.scala
@@ -24,17 +24,16 @@ import com.fortyseven.common.configuration.refinedTypes.*
 import pureconfig.ConfigReader
 import pureconfig.error.ExceptionThrown
 
-/**
- * It contains the givens for the types that pureConfig does not have automatic derivation.
- */
+/** It contains the givens for the types that pureConfig does not have automatic derivation.
+  */
 object refinedTypesGivens:
 
   given ConfigReader[NonEmptyString] = ConfigReader.fromString(NonEmptyString.from(_).leftMap(ExceptionThrown.apply))
 
   given ConfigReader[PositiveInt] = ConfigReader[Int].emap(PositiveInt.from(_).leftMap(ExceptionThrown.apply))
 
-  given ConfigReader[KafkaAutoOffsetReset] =
-    ConfigReader.fromString(KafkaAutoOffsetReset.from(_).leftMap(ExceptionThrown.apply))
+  given ConfigReader[KafkaAutoOffsetReset] = ConfigReader
+    .fromString(KafkaAutoOffsetReset.from(_).leftMap(ExceptionThrown.apply))
 
-  given ConfigReader[KafkaCompressionType] =
-    ConfigReader.fromString(KafkaCompressionType.from(_).leftMap(ExceptionThrown.apply))
+  given ConfigReader[KafkaCompressionType] = ConfigReader
+    .fromString(KafkaCompressionType.from(_).leftMap(ExceptionThrown.apply))

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfiguration.scala
@@ -25,7 +25,7 @@ import com.fortyseven.pureconfig.refinedTypesGivens.given
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.derived
 
-private[spark] final case class SparkProcessorConfiguration(
+final private[spark] case class SparkProcessorConfiguration(
     app: SparkProcessorApplicationConfiguration,
     streaming: SparkProcessorStreamingConfiguration,
     reader: SparkProcessorReaderConfiguration,
@@ -35,15 +35,17 @@ private[spark] final case class SparkProcessorConfiguration(
 object SparkProcessorConfiguration:
   given ConfigReader[SparkProcessorConfiguration] = ConfigReader.derived[SparkProcessorConfiguration]
 
-private[spark] final case class SparkProcessorApplicationConfiguration(
+final private[spark] case class SparkProcessorApplicationConfiguration(
     appName: NonEmptyString,
     masterUrl: NonEmptyString
 ) extends SparkProcessorApplicationConfigurationI
 
 object SparkProcessorApplicationConfiguration:
-  given ConfigReader[SparkProcessorApplicationConfiguration] = ConfigReader.derived[SparkProcessorApplicationConfiguration]
 
-private[spark] final case class SparkProcessorStreamingConfiguration(
+  given ConfigReader[SparkProcessorApplicationConfiguration] = ConfigReader
+    .derived[SparkProcessorApplicationConfiguration]
+
+final private[spark] case class SparkProcessorStreamingConfiguration(
     backpressureEnabled: Boolean,
     blockInterval: FiniteDuration,
     stopGracefullyOnShutdown: Boolean
@@ -52,21 +54,19 @@ private[spark] final case class SparkProcessorStreamingConfiguration(
 object SparkProcessorStreamingConfiguration:
   given ConfigReader[SparkProcessorStreamingConfiguration] = ConfigReader.derived[SparkProcessorStreamingConfiguration]
 
-private[spark] final case class SparkProcessorReaderConfiguration(
-    kafka: SparkProcessorKafkaConfiguration
-) extends SparkProcessorReaderConfigurationI
+final private[spark] case class SparkProcessorReaderConfiguration(kafka: SparkProcessorKafkaConfiguration)
+    extends SparkProcessorReaderConfigurationI
 
 object SparkProcessorReaderConfiguration:
   given ConfigReader[SparkProcessorReaderConfiguration] = ConfigReader.derived[SparkProcessorReaderConfiguration]
 
-private[spark] final case class SparkProcessorWriterConfiguration(
-    format: NonEmptyString
-) extends SparkProcessorWriterConfigurationI
+final private[spark] case class SparkProcessorWriterConfiguration(format: NonEmptyString)
+    extends SparkProcessorWriterConfigurationI
 
 object SparkProcessorWriterConfiguration:
   given ConfigReader[SparkProcessorWriterConfiguration] = ConfigReader.derived[SparkProcessorWriterConfiguration]
 
-private[spark] final case class SparkProcessorKafkaConfiguration(
+final private[spark] case class SparkProcessorKafkaConfiguration(
     bootstrapServers: NonEmptyString,
     topic: NonEmptyString,
     startingOffsets: NonEmptyString,

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfiguration.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfiguration.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration.FiniteDuration
 import com.fortyseven.common.configuration.*
 import com.fortyseven.common.configuration.refinedTypes.*
 import com.fortyseven.pureconfig.refinedTypesGivens.given
+
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.derived
 

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfigurationLoader.scala
@@ -23,11 +23,13 @@ import pureconfig.ConfigSource
 
 final class SparkProcessorConfigurationLoader extends ConfigurationAPI[Result, SparkProcessorConfiguration]:
 
-  /**
-   * @return
-   *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the method is mappable or flatMappable
-   *   since it is wrapped into an effect. Thus, you can use it in a for-comprehension. If the value of the configuration fails to be loaded, the
-   *   effect will handle the error gracefully.
-   */
-  override def load(): Result[SparkProcessorConfiguration] =
-    ConfigSource.default.at("processor-spark").load[SparkProcessorConfiguration]
+  /** @return
+    *   An instance of the the class [Configuration] wrapped into an effect of type [Effect]. The return type of the
+    *   method is mappable or flatMappable since it is wrapped into an effect. Thus, you can use it in a
+    *   for-comprehension. If the value of the configuration fails to be loaded, the effect will handle the error
+    *   gracefully.
+    */
+  override def load(): Result[SparkProcessorConfiguration] = ConfigSource
+    .default
+    .at("processor-spark")
+    .load[SparkProcessorConfiguration]

--- a/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfigurationLoader.scala
+++ b/03-c-config-pureconfig/src/main/scala/com/fortyseven/pureconfig/spark/SparkProcessorConfigurationLoader.scala
@@ -17,6 +17,7 @@
 package com.fortyseven.pureconfig.spark
 
 import com.fortyseven.common.api.ConfigurationAPI
+
 import pureconfig.ConfigReader.Result
 import pureconfig.ConfigSource
 

--- a/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/DataGenerator.scala
+++ b/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/DataGenerator.scala
@@ -16,18 +16,20 @@
 
 package com.fortyseven.datagenerator
 
-import scala.concurrent.duration.*
-
 import cats.Parallel
 import cats.effect.kernel.Async
 import cats.implicits.*
+import fs2.kafka.*
+
+import scala.concurrent.duration.*
+
+import org.apache.kafka.clients.producer.ProducerConfig
 
 import com.fortyseven.common.api.DataGeneratorAPI
 import com.fortyseven.common.configuration.DataGeneratorConfigurationI
 import com.fortyseven.domain.codecs.iot.IotCodecs.given
-import com.fortyseven.domain.model.iot.model.{GPSPosition, PneumaticPressure}
-import fs2.kafka.*
-import org.apache.kafka.clients.producer.ProducerConfig
+import com.fortyseven.domain.model.iot.model.GPSPosition
+import com.fortyseven.domain.model.iot.model.PneumaticPressure
 
 final class DataGenerator[F[_]: Async: Parallel] extends DataGeneratorAPI[F]:
 

--- a/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/ModelGenerators.scala
+++ b/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/ModelGenerators.scala
@@ -16,14 +16,14 @@
 
 package com.fortyseven.datagenerator
 
-import scala.concurrent.duration.*
-
 import cats.effect.Temporal
+import fs2.Stream
+
+import scala.concurrent.duration.*
 
 import com.fortyseven.domain.model.app.model.*
 import com.fortyseven.domain.model.iot.model.*
 import com.fortyseven.domain.model.types.refinedTypes.*
-import fs2.Stream
 
 final class ModelGenerators[F[_]: Temporal](meteredInterval: FiniteDuration):
 

--- a/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/ModelGenerators.scala
+++ b/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/ModelGenerators.scala
@@ -36,18 +36,17 @@ final class ModelGenerators[F[_]: Temporal](meteredInterval: FiniteDuration):
       def getValue(value: Double) = value - math.random() * 1e-3
 
       (Latitude.from(getValue(latValue)), Longitude.from(getValue(lonValue))) match
-        case (Right(lat), Right(lon)) =>
-          fs2.Stream.emit(GPSPosition(lat, lon)).metered(meteredInterval) ++ emitLoop(lat.value, lon.value)
+        case (Right(lat), Right(lon)) => fs2.Stream.emit(GPSPosition(lat, lon)).metered(meteredInterval) ++
+            emitLoop(lat.value, lon.value)
         case _ => emitLoop(latValue, lonValue)
 
     emitLoop(latValue = 2.0, lonValue = 2.0)
 
   def generatePneumaticPressure: fs2.Stream[F, PneumaticPressure] =
 
-    def emitLoop(pValue: Double): fs2.Stream[F, PneumaticPressure] =
-      Bar.from(pValue - math.random() * 1e-3) match
-        case Right(p) => fs2.Stream.emit(PneumaticPressure(p)).metered(meteredInterval) ++ emitLoop(p.value)
-        case _        => emitLoop(pValue)
+    def emitLoop(pValue: Double): fs2.Stream[F, PneumaticPressure] = Bar.from(pValue - math.random() * 1e-3) match
+      case Right(p) => fs2.Stream.emit(PneumaticPressure(p)).metered(meteredInterval) ++ emitLoop(p.value)
+      case _ => emitLoop(pValue)
 
     emitLoop(pValue = 2.0)
 
@@ -64,3 +63,5 @@ final class ModelGenerators[F[_]: Temporal](meteredInterval: FiniteDuration):
   def generateTotalDistancePerUser: fs2.Stream[F, TotalDistanceByUser] = ???
 
   def generateTotalRange: fs2.Stream[F, TotalRange] = ???
+
+end ModelGenerators

--- a/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/VulcanSerdes.scala
+++ b/03-u-data-generator/src/main/scala/com/fortyseven/datagenerator/VulcanSerdes.scala
@@ -20,11 +20,17 @@ import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import scala.util.control.NoStackTrace
 
+import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.common.serialization.Serializer
+
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
-import io.confluent.kafka.serializers.{KafkaAvroDeserializer, KafkaAvroSerializer}
-import org.apache.kafka.common.serialization.{Deserializer, Serde, Serdes, Serializer}
-import vulcan.{AvroError, Codec}
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import io.confluent.kafka.serializers.KafkaAvroSerializer
+import vulcan.AvroError
+import vulcan.Codec
 
 object VulcanSerdes:
 

--- a/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/DataGeneratorSuite.scala
+++ b/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/DataGeneratorSuite.scala
@@ -36,9 +36,14 @@ class DataGeneratorSuite extends CatsEffectSuite with ScalaCheckEffectSuite:
         _ = sample.foreach(it => assert(it.latitude.value >= -90.0 && it.latitude.value <= 90.0))
         _ = sample.foreach(it => assert(it.longitude.value >= -180.0 && it.longitude.value <= 180.0))
         _ = sample
-              .sliding(2).map(l =>
-                (math.abs(l.head.latitude.value - l.last.latitude.value), math.abs(l.head.longitude.value - l.last.longitude.value))
-              ).foreach(it => assert(it._1 <= 1e-3 && it._2 <= 1e-3))
+          .sliding(2)
+          .map(l =>
+            (
+              math.abs(l.head.latitude.value - l.last.latitude.value),
+              math.abs(l.head.longitude.value - l.last.longitude.value)
+            )
+          )
+          .foreach(it => assert(it._1 <= 1e-3 && it._2 <= 1e-3))
       yield ()
     }
 
@@ -47,6 +52,11 @@ class DataGeneratorSuite extends CatsEffectSuite with ScalaCheckEffectSuite:
       for
         sample <- dataGenerator.generatePneumaticPressure.take(sampleSize).compile.toList
         _ = sample.foreach(it => assert(it.pressure.value > 0.0))
-        _ = sample.sliding(2).map(l => l.head.pressure.value - l.last.pressure.value).foreach(it => assert(it >= 0 && it <= 1e-3))
+        _ = sample
+          .sliding(2)
+          .map(l => l.head.pressure.value - l.last.pressure.value)
+          .foreach(it => assert(it >= 0 && it <= 1e-3))
       yield ()
     }
+
+end DataGeneratorSuite

--- a/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/DataGeneratorSuite.scala
+++ b/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/DataGeneratorSuite.scala
@@ -16,11 +16,12 @@
 
 package com.fortyseven.datagenerator
 
-import scala.concurrent.duration.*
-
 import cats.effect.IO
 
-import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import scala.concurrent.duration.*
+
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
 import org.scalacheck.*
 import org.scalacheck.effect.PropF
 

--- a/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/VulcanSerdesSuite.scala
+++ b/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/VulcanSerdesSuite.scala
@@ -16,13 +16,15 @@
 
 package com.fortyseven.datagenerator
 
+import org.apache.kafka.common.serialization.Serde
+
 import com.fortyseven.domain.codecs.iot.IotCodecs.pneumaticPressureCodec
 import com.fortyseven.domain.model.iot.model.PneumaticPressure
 import com.fortyseven.domain.model.types.refinedTypes.Bar
+
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
 import munit.CatsEffectSuite
-import org.apache.kafka.common.serialization.Serde
 
 class VulcanSerdesSuite extends CatsEffectSuite:
 

--- a/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/VulcanSerdesSuite.scala
+++ b/03-u-data-generator/src/test/scala/com/fortyseven/datagenerator/VulcanSerdesSuite.scala
@@ -30,27 +30,31 @@ class VulcanSerdesSuite extends CatsEffectSuite:
 
   import VulcanSerdes.*
 
-  private def serialize[A](topic: String, data: A)(using serde: Serde[A]): Array[Byte] =
-    serde.serializer.serialize(topic, data)
+  private def serialize[A](topic: String, data: A)(using serde: Serde[A]): Array[Byte] = serde
+    .serializer
+    .serialize(topic, data)
 
-  private def deserialize[A](topic: String, bytes: Array[Byte])(using serde: Serde[A]): A =
-    serde.deserializer.deserialize(topic, bytes)
+  private def deserialize[A](topic: String, bytes: Array[Byte])(using serde: Serde[A]): A = serde
+    .deserializer
+    .deserialize(topic, bytes)
 
   test("Serialize a case class as a record"):
     val mockedClient = new MockSchemaRegistryClient()
-    val topic        = "test-topic"
+    val topic = "test-topic"
 
     pneumaticPressureCodec.schema match
-      case Left(_)       => ()
+      case Left(_) => ()
       case Right(schema) => mockedClient.register(s"$topic-value", AvroSchema(schema.toString))
-    val config                     = Configuration("useMockedClient", useMockedClient = Some(mockedClient))
+    val config = Configuration("useMockedClient", useMockedClient = Some(mockedClient))
     given Serde[PneumaticPressure] = avroSerde[PneumaticPressure](config, includeKey = false)
 
     val data: PneumaticPressure = PneumaticPressure(Bar(2.0))
 
     val result: PneumaticPressure =
-      val serialized   = serialize(topic, data)
+      val serialized = serialize(topic, data)
       val deserialized = deserialize(topic, serialized)
       deserialized
 
     assertEquals(data, result)
+
+end VulcanSerdesSuite

--- a/04-i-consumer-kafka/src/main/scala/com/fortyseven/kafkaconsumer/KafkaConsumer.scala
+++ b/04-i-consumer-kafka/src/main/scala/com/fortyseven/kafkaconsumer/KafkaConsumer.scala
@@ -16,17 +16,18 @@
 
 package com.fortyseven.kafkaconsumer
 
-import scala.util.matching.Regex
-
 import cats.*
 import cats.effect.kernel.Async
 import cats.implicits.*
+import fs2.kafka.*
+
+import scala.util.matching.Regex
+
+import org.apache.kafka.clients.producer.ProducerConfig
 
 import com.fortyseven.common.configuration.KafkaConsumerConfigurationI
 import com.fortyseven.common.configuration.refinedTypes.KafkaAutoOffsetReset
 import com.fortyseven.input.api.KafkaConsumerAPI
-import fs2.kafka.*
-import org.apache.kafka.clients.producer.ProducerConfig
 
 final class KafkaConsumer[F[_]: Async] extends KafkaConsumerAPI[F]:
 

--- a/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/DataProcessorIntegrationTest.scala
+++ b/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/DataProcessorIntegrationTest.scala
@@ -21,7 +21,8 @@ import cats.implicits.*
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.common.serialization.SimpleStringSchema
-import org.apache.flink.connector.kafka.sink.{KafkaRecordSerializationSchema, KafkaSink}
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema
+import org.apache.flink.connector.kafka.sink.KafkaSink
 import org.apache.flink.connector.kafka.source.KafkaSource
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer
 import org.apache.flink.core.execution.JobClient

--- a/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/DataProcessorIntegrationTest.scala
+++ b/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/DataProcessorIntegrationTest.scala
@@ -33,10 +33,10 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 object DataProcessorIntegrationTest extends IOApp.Simple:
 
   override def run: IO[Unit] =
-    val env              = StreamExecutionEnvironment.getExecutionEnvironment()
+    val env = StreamExecutionEnvironment.getExecutionEnvironment()
     val bootstrapServers = "localhost:9092"
-    val sourceTopic      = "input-topic"
-    val sinkTopic        = "output-topic"
+    val sourceTopic = "input-topic"
+    val sinkTopic = "output-topic"
     new DataProcessorIntegrationTest(env).run(bootstrapServers, sourceTopic, sinkTopic).void
 
   def runLocal(bootstrapServers: String, sourceTopic: String, sinkTopic: String): IO[Unit] =
@@ -77,3 +77,7 @@ final private class DataProcessorIntegrationTest(env: StreamExecutionEnvironment
       .sinkTo(kafkaSink)
 
     env.executeAsync("Flink Streaming").pure
+
+  end run
+
+end DataProcessorIntegrationTest

--- a/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/FlinkDataProcessor.scala
+++ b/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/FlinkDataProcessor.scala
@@ -19,8 +19,6 @@ package com.fortyseven.processor.flink
 import cats.Applicative
 import cats.implicits.*
 
-import com.fortyseven.common.configuration.FlinkProcessorConfigurationI
-import com.fortyseven.domain.codecs.iot.IotCodecs.given
 import org.apache.avro.Schema
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.connector.kafka.source.KafkaSource
@@ -28,6 +26,9 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsIni
 import org.apache.flink.core.execution.JobClient
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+import com.fortyseven.common.configuration.FlinkProcessorConfigurationI
+import com.fortyseven.domain.codecs.iot.IotCodecs.given
 
 final class FlinkDataProcessor[F[_]: Applicative](env: StreamExecutionEnvironment):
 

--- a/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/FlinkProcessor.scala
+++ b/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/FlinkProcessor.scala
@@ -27,12 +27,11 @@ import com.fortyseven.output.api.FlinkProcessorAPI
 
 final class FlinkProcessor[F[_]: Async] extends FlinkProcessorAPI[F]:
 
-  /**
-   * @param configuration
-   *   An instance of [[ProcessorConfiguration]] class that extends [[ConfigurationAPI]].
-   * @return
-   *   It executes the effects of the Flink Processor and returns Unit.
-   */
+  /** @param configuration
+    *   An instance of [[ProcessorConfiguration]] class that extends [[ConfigurationAPI]].
+    * @return
+    *   It executes the effects of the Flink Processor and returns Unit.
+    */
   override def process[Configuration <: FlinkProcessorConfigurationI](configuration: Configuration): F[Unit] =
     runWithConfiguration(configuration)
 
@@ -44,3 +43,5 @@ final class FlinkProcessor[F[_]: Async] extends FlinkProcessorAPI[F]:
 
   private def runWithConfiguration(jpc: FlinkProcessorConfigurationI): F[Unit] =
     new FlinkDataProcessor(setAndGetEnvironment()).run(jpc).void
+
+end FlinkProcessor

--- a/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/FlinkProcessor.scala
+++ b/04-o-processor-flink/src/main/scala/com/fortyseven/processor/flink/FlinkProcessor.scala
@@ -20,9 +20,10 @@ import cats.*
 import cats.effect.kernel.Async
 import cats.implicits.*
 
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
 import com.fortyseven.common.configuration.FlinkProcessorConfigurationI
 import com.fortyseven.output.api.FlinkProcessorAPI
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 
 final class FlinkProcessor[F[_]: Async] extends FlinkProcessorAPI[F]:
 

--- a/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/Main.scala
+++ b/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/Main.scala
@@ -19,10 +19,11 @@ package com.fortyseven.processor.spark
 import com.fortyseven.pureconfig.spark.SparkProcessorConfigurationLoader
 
 object Main:
+
   def main(args: Array[String]): Unit =
     val sparkProcessorConfiguration = new SparkProcessorConfigurationLoader
-    val sparkProcessorConf          = sparkProcessorConfiguration.load()
-    val app                         = new SparkProcessor
+    val sparkProcessorConf = sparkProcessorConfiguration.load()
+    val app = new SparkProcessor
     sparkProcessorConf.fold(
       configReaderFailures => throw new Exception(configReaderFailures.toString),
       processorConfiguration => app.process(processorConfiguration)

--- a/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkEngine.scala
+++ b/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkEngine.scala
@@ -26,39 +26,32 @@ import com.fortyseven.common.configuration.SparkProcessorConfigurationI
 import com.fortyseven.common.configuration.SparkProcessorReaderConfigurationI
 import com.fortyseven.common.configuration.SparkProcessorWriterConfigurationI
 
-private[spark] final class SparkEngine(sparkSession: SparkSession):
+final private[spark] class SparkEngine(sparkSession: SparkSession):
 
   def run(sparkProcessorConfiguration: SparkProcessorConfigurationI): Unit =
 
     extension (sparkSession: SparkSession)
-      def buildReader(reader: SparkProcessorReaderConfigurationI): DataFrameReader =
-        sparkSession.read
-          .format("kafka")
-          .option(
-            "kafka.bootstrap.servers",
-            reader.kafka.bootstrapServers
-          )
-          .option(
-            "subscribePattern",
-            reader.kafka.topic
-          )
-          .option(
-            "startingOffsets",
-            reader.kafka.startingOffsets
-          )
-          .option(
-            "endingOffsets",
-            reader.kafka.endingOffsets
-          )
+      def buildReader(reader: SparkProcessorReaderConfigurationI): DataFrameReader = sparkSession
+        .read
+        .format("kafka")
+        .option("kafka.bootstrap.servers", reader.kafka.bootstrapServers)
+        .option("subscribePattern", reader.kafka.topic)
+        .option("startingOffsets", reader.kafka.startingOffsets)
+        .option("endingOffsets", reader.kafka.endingOffsets)
 
     extension (dataFrameReader: DataFrameReader) def applyLogic(): DataFrame = dataFrameReader.load()
 
     extension (dataFrame: DataFrame)
-      def buildWriter(writer: SparkProcessorWriterConfigurationI): DataFrameWriter[Row] =
-        dataFrame.write.format(writer.format)
+      def buildWriter(writer: SparkProcessorWriterConfigurationI): DataFrameWriter[Row] = dataFrame
+        .write
+        .format(writer.format)
 
     sparkSession
       .buildReader(sparkProcessorConfiguration.reader)
       .applyLogic()
       .buildWriter(sparkProcessorConfiguration.writer)
       .save()
+
+  end run
+
+end SparkEngine

--- a/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkEngine.scala
+++ b/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkEngine.scala
@@ -16,8 +16,15 @@
 
 package com.fortyseven.processor.spark
 
-import com.fortyseven.common.configuration.{SparkProcessorConfigurationI, SparkProcessorReaderConfigurationI, SparkProcessorWriterConfigurationI}
-import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SparkSession}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.DataFrameReader
+import org.apache.spark.sql.DataFrameWriter
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+
+import com.fortyseven.common.configuration.SparkProcessorConfigurationI
+import com.fortyseven.common.configuration.SparkProcessorReaderConfigurationI
+import com.fortyseven.common.configuration.SparkProcessorWriterConfigurationI
 
 private[spark] final class SparkEngine(sparkSession: SparkSession):
 

--- a/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkProcessor.scala
+++ b/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkProcessor.scala
@@ -16,10 +16,11 @@
 
 package com.fortyseven.processor.spark
 
-import com.fortyseven.common.configuration.SparkProcessorConfigurationI
-import com.fortyseven.output.api.SparkProcessorAPI
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+
+import com.fortyseven.common.configuration.SparkProcessorConfigurationI
+import com.fortyseven.output.api.SparkProcessorAPI
 
 class SparkProcessor extends SparkProcessorAPI:
 

--- a/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkProcessor.scala
+++ b/04-o-processor-spark/src/main/scala/com/fortyseven/processor/spark/SparkProcessor.scala
@@ -42,3 +42,7 @@ class SparkProcessor extends SparkProcessorAPI:
     val spark = SparkSession.builder.config(sparkConf).getOrCreate()
 
     new SparkEngine(spark).run(sparkProcessorConfiguration)
+
+  end runWithConfiguration
+
+end SparkProcessor

--- a/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorCirisMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorCirisMain.scala
@@ -16,17 +16,19 @@
 
 package com.fortyseven.main
 
-import cats.effect.{IO, IOApp}
+import cats.effect.IO
+import cats.effect.IOApp
 
 import com.fortyseven.cirisconfiguration.datagenerator.DataGeneratorConfigurationLoader
 import com.fortyseven.datagenerator.DataGenerator
+
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object DataGeneratorCirisMain extends IOApp.Simple:
 
   override def run: IO[Unit] = for
     logger      <- Slf4jLogger.create[IO]
-    _           <- logger.info(s"Loading Data Generator Configuration")
+    _           <- logger.info("Loading Data Generator Configuration")
     dataGenConf <- DataGeneratorConfigurationLoader[IO].load()
     _           <- logger.info("Start data generator")
     _           <- new DataGenerator[IO].generate(dataGenConf)

--- a/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorCirisMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorCirisMain.scala
@@ -26,10 +26,11 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object DataGeneratorCirisMain extends IOApp.Simple:
 
-  override def run: IO[Unit] = for
-    logger      <- Slf4jLogger.create[IO]
-    _           <- logger.info("Loading Data Generator Configuration")
-    dataGenConf <- DataGeneratorConfigurationLoader[IO].load()
-    _           <- logger.info("Start data generator")
-    _           <- new DataGenerator[IO].generate(dataGenConf)
-  yield ()
+  override def run: IO[Unit] =
+    for
+      logger <- Slf4jLogger.create[IO]
+      _ <- logger.info("Loading Data Generator Configuration")
+      dataGenConf <- DataGeneratorConfigurationLoader[IO].load()
+      _ <- logger.info("Start data generator")
+      _ <- new DataGenerator[IO].generate(dataGenConf)
+    yield ()

--- a/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorPureconfigMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorPureconfigMain.scala
@@ -26,10 +26,11 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object DataGeneratorPureconfigMain extends IOApp.Simple:
 
-  override def run: IO[Unit] = for
-    logger      <- Slf4jLogger.create[IO]
-    _           <- logger.info("Loading Data Generator Configuration")
-    dataGenConf <- DataGeneratorConfigurationLoader[IO].load()
-    _           <- logger.info("Start data generator")
-    _           <- new DataGenerator[IO].generate(dataGenConf)
-  yield ()
+  override def run: IO[Unit] =
+    for
+      logger <- Slf4jLogger.create[IO]
+      _ <- logger.info("Loading Data Generator Configuration")
+      dataGenConf <- DataGeneratorConfigurationLoader[IO].load()
+      _ <- logger.info("Start data generator")
+      _ <- new DataGenerator[IO].generate(dataGenConf)
+    yield ()

--- a/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorPureconfigMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/DataGeneratorPureconfigMain.scala
@@ -16,17 +16,19 @@
 
 package com.fortyseven.main
 
-import cats.effect.{IO, IOApp}
+import cats.effect.IO
+import cats.effect.IOApp
 
 import com.fortyseven.datagenerator.DataGenerator
 import com.fortyseven.pureconfig.datagenerator.DataGeneratorConfigurationLoader
+
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object DataGeneratorPureconfigMain extends IOApp.Simple:
 
   override def run: IO[Unit] = for
     logger      <- Slf4jLogger.create[IO]
-    _           <- logger.info(s"Loading Data Generator Configuration")
+    _           <- logger.info("Loading Data Generator Configuration")
     dataGenConf <- DataGeneratorConfigurationLoader[IO].load()
     _           <- logger.info("Start data generator")
     _           <- new DataGenerator[IO].generate(dataGenConf)

--- a/05-c-main/src/main/scala/com/fortyseven/main/FlinkCirisMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/FlinkCirisMain.scala
@@ -28,14 +28,17 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object FlinkCirisMain extends IOApp.Simple:
 
-  override def run: IO[Unit] = for
-    logger         <- Slf4jLogger.create[IO]
-    kafkaConf      <- new KafkaConsumerConfigurationLoader[IO].load()
-    flinkConf      <- new FlinkProcessorConfigurationLoader[IO].load()
-    _              <- logger.info("Start kafka consumer")
-    consumerFiber  <- new KafkaConsumer[IO].consume(kafkaConf).start
-    _              <- logger.info("Start flink processor")
-    processorFiber <- new FlinkProcessor[IO].process(flinkConf).start
-    _              <- consumerFiber.join
-    _              <- processorFiber.join
-  yield ()
+  override def run: IO[Unit] =
+    for
+      logger <- Slf4jLogger.create[IO]
+      kafkaConf <- new KafkaConsumerConfigurationLoader[IO].load()
+      flinkConf <- new FlinkProcessorConfigurationLoader[IO].load()
+      _ <- logger.info("Start kafka consumer")
+      consumerFiber <- new KafkaConsumer[IO].consume(kafkaConf).start
+      _ <- logger.info("Start flink processor")
+      processorFiber <- new FlinkProcessor[IO].process(flinkConf).start
+      _ <- consumerFiber.join
+      _ <- processorFiber.join
+    yield ()
+
+end FlinkCirisMain

--- a/05-c-main/src/main/scala/com/fortyseven/main/FlinkCirisMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/FlinkCirisMain.scala
@@ -16,12 +16,14 @@
 
 package com.fortyseven.main
 
-import cats.effect.{IO, IOApp}
+import cats.effect.IO
+import cats.effect.IOApp
 
 import com.fortyseven.cirisconfiguration.flink.FlinkProcessorConfigurationLoader
 import com.fortyseven.cirisconfiguration.kafkaconsumer.KafkaConsumerConfigurationLoader
 import com.fortyseven.kafkaconsumer.KafkaConsumer
 import com.fortyseven.processor.flink.FlinkProcessor
+
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object FlinkCirisMain extends IOApp.Simple:

--- a/05-c-main/src/main/scala/com/fortyseven/main/FlinkPureconfigMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/FlinkPureconfigMain.scala
@@ -16,12 +16,14 @@
 
 package com.fortyseven.main
 
-import cats.effect.{IO, IOApp}
+import cats.effect.IO
+import cats.effect.IOApp
 
 import com.fortyseven.kafkaconsumer.KafkaConsumer
 import com.fortyseven.processor.flink.FlinkProcessor
 import com.fortyseven.pureconfig.flink.FlinkProcessorConfigurationLoader
 import com.fortyseven.pureconfig.kafkaconsumer.KafkaConsumerConfigurationLoader
+
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object FlinkPureconfigMain extends IOApp.Simple:

--- a/05-c-main/src/main/scala/com/fortyseven/main/FlinkPureconfigMain.scala
+++ b/05-c-main/src/main/scala/com/fortyseven/main/FlinkPureconfigMain.scala
@@ -28,14 +28,17 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 object FlinkPureconfigMain extends IOApp.Simple:
 
-  override def run: IO[Unit] = for
-    logger         <- Slf4jLogger.create[IO]
-    kafkaConf      <- new KafkaConsumerConfigurationLoader[IO].load()
-    flinkConf      <- new FlinkProcessorConfigurationLoader[IO].load()
-    _              <- logger.info("Start kafka consumer")
-    consumerFiber  <- new KafkaConsumer[IO].consume(kafkaConf).start
-    _              <- logger.info("Start flink processor")
-    processorFiber <- new FlinkProcessor[IO].process(flinkConf).start
-    _              <- consumerFiber.join
-    _              <- processorFiber.join
-  yield ()
+  override def run: IO[Unit] =
+    for
+      logger <- Slf4jLogger.create[IO]
+      kafkaConf <- new KafkaConsumerConfigurationLoader[IO].load()
+      flinkConf <- new FlinkProcessorConfigurationLoader[IO].load()
+      _ <- logger.info("Start kafka consumer")
+      consumerFiber <- new KafkaConsumer[IO].consume(kafkaConf).start
+      _ <- logger.info("Start flink processor")
+      processorFiber <- new FlinkProcessor[IO].process(flinkConf).start
+      _ <- consumerFiber.join
+      _ <- processorFiber.join
+    yield ()
+
+end FlinkPureconfigMain

--- a/aliases.sbt
+++ b/aliases.sbt
@@ -24,72 +24,44 @@ addCommandAlias("rs", "reStart")
 
 addCommandAlias("s", "reStop")
 
-addCommandAlias(
-  "styleCheck",
-  "scalafixAll --check; scalafmtSbtCheck; scalafmtCheckAll"
-)
+addCommandAlias("styleCheck", "scalafixAll --check; scalafmtSbtCheck; scalafmtCheckAll")
 
-addCommandAlias(
-  "styleFix",
-  "scalafixAll; scalafmtSbt; scalafmtAll"
-)
+addCommandAlias("styleFix", "scalafixAll; scalafmtSbt; scalafmtAll")
 
-addCommandAlias(
-  "explicit",
-  "undeclaredCompileDependenciesTest"
-)
+addCommandAlias("explicit", "undeclaredCompileDependenciesTest")
 
-addCommandAlias(
-  "up2date",
-  "reload plugins; reload return; dependencyUpdates"
-)
+addCommandAlias("up2date", "reload plugins; reload return; dependencyUpdates")
 
-addCommandAlias(
-  "runCoverage",
-  "clean; coverage; test; coverageReport; coverageAggregate"
-)
+addCommandAlias("runCoverage", "clean; coverage; test; coverageReport; coverageAggregate")
 
-addCommandAlias(
-  "flinkIT",
-  "processor-flink-integration / test"
-)
+addCommandAlias("flinkIT", "processor-flink-integration / test")
 
-addCommandAlias(
-  "runFlink",
-  "main/runMain com.fortyseven.main.FlinkMain;"
-)
+addCommandAlias("runFlink", "main/runMain com.fortyseven.main.FlinkMain;")
 
-addCommandAlias(
-  "generateData",
-  "main/runMain com.fortyseven.main.DataGeneratorMain;"
-)
+addCommandAlias("generateData", "main/runMain com.fortyseven.main.DataGeneratorMain;")
 
-addCommandAlias(
-  "runSpark",
-  "processor-spark/run;"
-)
+addCommandAlias("runSpark", "processor-spark/run;")
 
-onLoadMessage +=
-  s"""|
-      |╭─────────────┴─────────────────────────────╮
-      |│     List of defined ${styled("aliases")}               │
-      |├─────────────┴─────────────────────────────┤
-      |│ ${styled("l")} | ${styled("ll")} | ${styled("ls")} │ projects                    │
-      |│ ${styled("cd")}          │ project                     │
-      |│ ${styled("root")}        │ cd root                     │
-      |│ ${styled("c")}           │ compile                     │
-      |│ ${styled("ct")}          │ compile test                │
-      |│ ${styled("t")}           │ test                        │
-      |│ ${styled("r")}           │ run                         │
-      |│ ${styled("rs")}          │ reStart                     │
-      |│ ${styled("s")}           │ reStop                      │
-      |│ ${styled("styleCheck")}  │ scala fix & fmt check       │
-      |│ ${styled("styleFix")}    │ scala fix & fmt             │
-      || ${styled("explicit")}    | transitive dependency check |
-      |│ ${styled("up2date")}     │ dependency updates          │
-      |│ ${styled("runCoverage")} │ coverage report
-      |│ ${styled("generateData")}│ start sending dummy data
-      |│ ${styled("flinkIT")}     │ run flink integration tests │
-      |│ ${styled("runFlink")}    │ run flink                   │
-      |│ ${styled("runSpark")}    │ run spark                   │
-      |╰─────────────┴─────────────────────────────╯""".stripMargin
+onLoadMessage += s"""|
+  |╭─────────────┴─────────────────────────────╮
+  |│     List of defined ${styled("aliases")}               │
+  |├─────────────┴─────────────────────────────┤
+  |│ ${styled("l")} | ${styled("ll")} | ${styled("ls")} │ projects                    │
+  |│ ${styled("cd")}          │ project                     │
+  |│ ${styled("root")}        │ cd root                     │
+  |│ ${styled("c")}           │ compile                     │
+  |│ ${styled("ct")}          │ compile test                │
+  |│ ${styled("t")}           │ test                        │
+  |│ ${styled("r")}           │ run                         │
+  |│ ${styled("rs")}          │ reStart                     │
+  |│ ${styled("s")}           │ reStop                      │
+  |│ ${styled("styleCheck")}  │ scala fix & fmt check       │
+  |│ ${styled("styleFix")}    │ scala fix & fmt             │
+  || ${styled("explicit")}    | transitive dependency check |
+  |│ ${styled("up2date")}     │ dependency updates          │
+  |│ ${styled("runCoverage")} │ coverage report
+  |│ ${styled("generateData")}│ start sending dummy data
+  |│ ${styled("flinkIT")}     │ run flink integration tests │
+  |│ ${styled("runFlink")}    │ run flink                   │
+  |│ ${styled("runSpark")}    │ run spark                   │
+  |╰─────────────┴─────────────────────────────╯""".stripMargin

--- a/build.sbt
+++ b/build.sbt
@@ -5,270 +5,236 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / organization := "com.47deg"
 
-ThisBuild / scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/47deg/poc-scala-data-streaming"),
-    "scm:git@github.com:47deg/poc-scala-data-streaming.git"
-  )
-)
+ThisBuild / scmInfo := Some(ScmInfo(
+  url("https://github.com/47deg/poc-scala-data-streaming"),
+  "scm:git@github.com:47deg/poc-scala-data-streaming.git"
+))
 
 ThisBuild / scalaVersion := "3.3.0"
 
 ThisBuild / semanticdbEnabled := true
 
-ThisBuild / scalacOptions ++=
-  Seq(
-    "-deprecation",
-    "-explain",
-    "-feature",
-    "-language:implicitConversions",
-    "-unchecked",
-    "-Xfatal-warnings",
-    "-Ykind-projector",
-    "-Wunused:all",
-    "-Wvalue-discard"
-  ) ++ Seq("-rewrite", "-indent") ++ Seq("-source", "future-migration")
+ThisBuild / scalacOptions ++= Seq(
+  "-deprecation",
+  "-explain",
+  "-feature",
+  "-language:implicitConversions",
+  "-unchecked",
+  "-Xfatal-warnings",
+  "-Ykind-projector",
+  "-Wunused:all",
+  "-Wvalue-discard"
+) ++ Seq("-rewrite", "-indent") ++ Seq("-source", "future-migration")
 
 ThisBuild / assemblyMergeStrategy := {
   case PathList(ps @ _*) if ps.lastOption.contains("module-info.class") => MergeStrategy.discard
-  case x if x.endsWith(".properties")                                   => MergeStrategy.filterDistinctLines
+  case x if x.endsWith(".properties") => MergeStrategy.filterDistinctLines
   case x =>
     val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 
-lazy val `poc-scala-data-streaming`: Project =
-  project
-    .in(file("."))
-    .aggregate(
-      // Layer 1 - Domain
-      `domain`,
-      // Layer 2 - APIs
-      // APIs
-      `common-api`,
-      `input-api`,
-      `output-api`,
-      // Layer 3 - Business Logic, Common and Utils
-      // Business Logic
-      `business-logic`,
-      // Common
-      `configuration-ciris`,
-      `configuration-pureconfig`,
-      // Utils
-      `data-generator`,
-      // Layer 4 - Implementations
-      // Input
-      `consumer-kafka`,
-      // Output
-      `processor-flink`,
-      `processor-spark`,
-      // Layer 5 - Program
-      main
-    )
+lazy val `poc-scala-data-streaming`: Project = project
+  .in(file("."))
+  .aggregate(
+    // Layer 1 - Domain
+    `domain`,
+    // Layer 2 - APIs
+    // APIs
+    `common-api`,
+    `input-api`,
+    `output-api`,
+    // Layer 3 - Business Logic, Common and Utils
+    // Business Logic
+    `business-logic`,
+    // Common
+    `configuration-ciris`,
+    `configuration-pureconfig`,
+    // Utils
+    `data-generator`,
+    // Layer 4 - Implementations
+    // Input
+    `consumer-kafka`,
+    // Output
+    `processor-flink`,
+    `processor-spark`,
+    // Layer 5 - Program
+    main
+  )
 
 // Layer 1 - Domain
 
-lazy val domain: Project =
-  project
-    .in(file("01-c-domain"))
-    .settings(commonSettings)
-    .settings(
-      name := "domain",
-      libraryDependencies ++= Seq(
-        Libraries.avro.vulcan,
-        Libraries.avro.avro,
-        Libraries.cats.free,
-        Libraries.cats.core,
-        Libraries.test.munitScalacheck
-      )
+lazy val domain: Project = project
+  .in(file("01-c-domain"))
+  .settings(commonSettings)
+  .settings(
+    name := "domain",
+    libraryDependencies ++= Seq(
+      Libraries.avro.vulcan,
+      Libraries.avro.avro,
+      Libraries.cats.free,
+      Libraries.cats.core,
+      Libraries.test.munitScalacheck
     )
+  )
 
 // Layer 2 - APIs, Common and Utils
 
 // APIs
 
-lazy val `common-api`: Project =
-  project
-    .in(file("02-c-api"))
-    .dependsOn(domain % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "common-api",
-      libraryDependencies ++= Seq()
-    )
+lazy val `common-api`: Project = project
+  .in(file("02-c-api"))
+  .dependsOn(domain % Cctt)
+  .settings(commonSettings)
+  .settings(name := "common-api", libraryDependencies ++= Seq())
 
-lazy val `input-api`: Project =
-  project
-    .in(file("02-i-api"))
-    .dependsOn(`common-api` % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "input-api",
-      libraryDependencies ++= Seq()
-    )
+lazy val `input-api`: Project = project
+  .in(file("02-i-api"))
+  .dependsOn(`common-api` % Cctt)
+  .settings(commonSettings)
+  .settings(name := "input-api", libraryDependencies ++= Seq())
 
-lazy val `output-api`: Project =
-  project
-    .in(file("02-o-api"))
-    .dependsOn(`common-api` % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "output-api",
-      libraryDependencies ++= Seq()
-    )
+lazy val `output-api`: Project = project
+  .in(file("02-o-api"))
+  .dependsOn(`common-api` % Cctt)
+  .settings(commonSettings)
+  .settings(name := "output-api", libraryDependencies ++= Seq())
 
 // Layer 3 - Business Logic, Common and Utils
 
 // Business Logic
 
-lazy val `business-logic`: Project =
-  project
-    .in(file("03-c-business-logic"))
-    .dependsOn(domain % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "business-logic",
-      libraryDependencies ++= Seq(
-      )
-    )
+lazy val `business-logic`: Project = project
+  .in(file("03-c-business-logic"))
+  .dependsOn(domain % Cctt)
+  .settings(commonSettings)
+  .settings(name := "business-logic", libraryDependencies ++= Seq())
 
 // Common
 
-lazy val `configuration-ciris`: Project =
-  project
-    .in(file("03-c-config-ciris"))
-    .dependsOn(`common-api` % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "ciris",
-      libraryDependencies ++= Seq(
-        Libraries.config.ciris,
-        Libraries.cats.effectKernel
-      )
-    )
+lazy val `configuration-ciris`: Project = project
+  .in(file("03-c-config-ciris"))
+  .dependsOn(`common-api` % Cctt)
+  .settings(commonSettings)
+  .settings(name := "ciris", libraryDependencies ++= Seq(Libraries.config.ciris, Libraries.cats.effectKernel))
 
-lazy val `configuration-pureconfig`: Project =
-  project
-    .in(file("03-c-config-pureconfig"))
-    .dependsOn(`common-api` % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "pureconfig",
-      libraryDependencies ++= Seq(
-        Libraries.config.pureConfig,
-        Libraries.cats.core,
-        Libraries.cats.effectKernel,
-        Libraries.config.pureConfigCE,
-        Libraries.test.munitCatsEffect
-      )
+lazy val `configuration-pureconfig`: Project = project
+  .in(file("03-c-config-pureconfig"))
+  .dependsOn(`common-api` % Cctt)
+  .settings(commonSettings)
+  .settings(
+    name := "pureconfig",
+    libraryDependencies ++= Seq(
+      Libraries.config.pureConfig,
+      Libraries.cats.core,
+      Libraries.cats.effectKernel,
+      Libraries.config.pureConfigCE,
+      Libraries.test.munitCatsEffect
     )
+  )
 
 // Utils
 
-lazy val `data-generator`: Project =
-  project
-    .in(file("03-u-data-generator"))
-    .dependsOn(`common-api`)
-    .enablePlugins(DockerPlugin)
-    .enablePlugins(JavaAppPackaging)
-    .settings(commonSettings)
-    .settings(
-      name                 := "data-generator",
-      assembly / mainClass := Some("com.fortyseven.datagenerator.Main"),
-      Docker / packageName := "data-generator",
-      dockerBaseImage      := "openjdk:11-jre-slim-buster",
-      dockerExposedPorts ++= Seq(8080),
-      dockerUpdateLatest := true,
-      dockerAlias := DockerAlias(
-        registryHost = Some("ghcr.io"),
-        username = Some((ThisBuild / organization).value),
-        name = (Docker / packageName).value,
-        tag = Some("latest")
-      ),
-      libraryDependencies ++= Seq(
-        Libraries.fs2.core,
-        Libraries.fs2.kafka,
-        Libraries.kafka.kafkaClients,
-        Libraries.cats.core,
-        Libraries.cats.effect,
-        Libraries.cats.effectKernel,
-        Libraries.avro.vulcan,
-        Libraries.avro.avro,
-        Libraries.kafka.kafkaSchemaRegistry,
-        Libraries.kafka.kafkaSchemaSerializer,
-        Libraries.kafka.kafkaSerializer,
-        Libraries.test.munitCatsEffect,
-        Libraries.test.munitScalacheck
-      )
+lazy val `data-generator`: Project = project
+  .in(file("03-u-data-generator"))
+  .dependsOn(`common-api`)
+  .enablePlugins(DockerPlugin)
+  .enablePlugins(JavaAppPackaging)
+  .settings(commonSettings)
+  .settings(
+    name := "data-generator",
+    assembly / mainClass := Some("com.fortyseven.datagenerator.Main"),
+    Docker / packageName := "data-generator",
+    dockerBaseImage := "openjdk:11-jre-slim-buster",
+    dockerExposedPorts ++= Seq(8080),
+    dockerUpdateLatest := true,
+    dockerAlias := DockerAlias(
+      registryHost = Some("ghcr.io"),
+      username = Some((ThisBuild / organization).value),
+      name = (Docker / packageName).value,
+      tag = Some("latest")
+    ),
+    libraryDependencies ++= Seq(
+      Libraries.fs2.core,
+      Libraries.fs2.kafka,
+      Libraries.kafka.kafkaClients,
+      Libraries.cats.core,
+      Libraries.cats.effect,
+      Libraries.cats.effectKernel,
+      Libraries.avro.vulcan,
+      Libraries.avro.avro,
+      Libraries.kafka.kafkaSchemaRegistry,
+      Libraries.kafka.kafkaSchemaSerializer,
+      Libraries.kafka.kafkaSerializer,
+      Libraries.test.munitCatsEffect,
+      Libraries.test.munitScalacheck
     )
+  )
 
 // Layer 4 - Implementations
 
 // Input
 
-lazy val `consumer-kafka`: Project =
-  project
-    .in(file("04-i-consumer-kafka"))
-    .dependsOn(`input-api` % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "kafka-consumer",
-      libraryDependencies ++= Seq(
-        Libraries.cats.core,
-        Libraries.cats.effectKernel,
-        Libraries.kafka.kafkaClients,
-        Libraries.fs2.kafka,
-        Libraries.fs2.core
-      )
+lazy val `consumer-kafka`: Project = project
+  .in(file("04-i-consumer-kafka"))
+  .dependsOn(`input-api` % Cctt)
+  .settings(commonSettings)
+  .settings(
+    name := "kafka-consumer",
+    libraryDependencies ++= Seq(
+      Libraries.cats.core,
+      Libraries.cats.effectKernel,
+      Libraries.kafka.kafkaClients,
+      Libraries.fs2.kafka,
+      Libraries.fs2.core
     )
+  )
 
 // Output
 
-lazy val `processor-flink`: Project =
-  project
-    .in(file("04-o-processor-flink"))
-    .dependsOn(`output-api` % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "flink",
-      libraryDependencies ++= Seq(
-        Libraries.avro.avro,
-        Libraries.avro.vulcan,
-        Libraries.cats.core,
-        Libraries.cats.effect,
-        Libraries.cats.effectKernel,
-        Libraries.flink.avro,
-        Libraries.flink.avroConfluent,
-        Libraries.flink.clients,
-        Libraries.flink.core,
-        Libraries.flink.kafka,
-        Libraries.flink.streaming,
-        Libraries.fs2.kafkaVulcan,
-        Libraries.kafka.kafkaClients,
-        Libraries.logging.catsCore,
-        Libraries.logging.catsSlf4j,
-        Libraries.logging.logback
-      )
+lazy val `processor-flink`: Project = project
+  .in(file("04-o-processor-flink"))
+  .dependsOn(`output-api` % Cctt)
+  .settings(commonSettings)
+  .settings(
+    name := "flink",
+    libraryDependencies ++= Seq(
+      Libraries.avro.avro,
+      Libraries.avro.vulcan,
+      Libraries.cats.core,
+      Libraries.cats.effect,
+      Libraries.cats.effectKernel,
+      Libraries.flink.avro,
+      Libraries.flink.avroConfluent,
+      Libraries.flink.clients,
+      Libraries.flink.core,
+      Libraries.flink.kafka,
+      Libraries.flink.streaming,
+      Libraries.fs2.kafkaVulcan,
+      Libraries.kafka.kafkaClients,
+      Libraries.logging.catsCore,
+      Libraries.logging.catsSlf4j,
+      Libraries.logging.logback
     )
+  )
 
-lazy val `processor-flink-integration`: Project =
-  project
-    .in(file("04-o-processor-flink/integration"))
-    .dependsOn(`processor-flink`)
-    .settings(commonSettings)
-    .settings(
-      name           := "integration-test",
-      publish / skip := true,
-      libraryDependencies ++= Seq(
-        Libraries.testContainers.kafka,
-        Libraries.testContainers.munit,
-        Libraries.logging.catsCore,
-        Libraries.logging.catsSlf4j,
-        Libraries.logging.logback,
-        Libraries.test.munitCatsEffect
-      ),
-      javacOptions ++= Seq("-source", "11", "-target", "11")
-    )
+lazy val `processor-flink-integration`: Project = project
+  .in(file("04-o-processor-flink/integration"))
+  .dependsOn(`processor-flink`)
+  .settings(commonSettings)
+  .settings(
+    name := "integration-test",
+    publish / skip := true,
+    libraryDependencies ++= Seq(
+      Libraries.testContainers.kafka,
+      Libraries.testContainers.munit,
+      Libraries.logging.catsCore,
+      Libraries.logging.catsSlf4j,
+      Libraries.logging.logback,
+      Libraries.test.munitCatsEffect
+    ),
+    javacOptions ++= Seq("-source", "11", "-target", "11")
+  )
 
 lazy val `processor-spark`: Project = project
   .in(file("04-o-processor-spark"))
@@ -284,62 +250,52 @@ lazy val `processor-spark`: Project = project
       Libraries.spark.streaming,
       Libraries.spark.`sql-kafka`
     ).map(_.cross(CrossVersion.for3Use2_13)),
-    Compile / run := Defaults
-      .runTask(
-        Compile / fullClasspath,
-        Compile / run / mainClass,
-        Compile / run / runner
-      ).evaluated,
+    Compile / run :=
+      Defaults.runTask(Compile / fullClasspath, Compile / run / mainClass, Compile / run / runner).evaluated,
     javacOptions ++= Seq("-source", "17", "-target", "17"),
     assembly / assemblyJarName := "spark-app.jar"
   )
 
 // Layer 5 - Program
 
-lazy val main: Project =
-  project
-    .in(file("05-c-main"))
-    .dependsOn(`configuration-ciris` % Cctt)
-    .dependsOn(`configuration-pureconfig` % Cctt)
-    .dependsOn(`consumer-kafka` % Cctt)
-    .dependsOn(`data-generator` % Cctt)
-    .dependsOn(`processor-flink` % Cctt)
-    .settings(commonSettings)
-    .settings(
-      name := "app",
-      libraryDependencies ++= Seq(
-        Libraries.cats.core,
-        Libraries.cats.effect,
-        Libraries.cats.effectKernel,
-        Libraries.logging.catsCore,
-        Libraries.logging.catsSlf4j,
-        Libraries.logging.logback
-      )
+lazy val main: Project = project
+  .in(file("05-c-main"))
+  .dependsOn(`configuration-ciris` % Cctt)
+  .dependsOn(`configuration-pureconfig` % Cctt)
+  .dependsOn(`consumer-kafka` % Cctt)
+  .dependsOn(`data-generator` % Cctt)
+  .dependsOn(`processor-flink` % Cctt)
+  .settings(commonSettings)
+  .settings(
+    name := "app",
+    libraryDependencies ++= Seq(
+      Libraries.cats.core,
+      Libraries.cats.effect,
+      Libraries.cats.effectKernel,
+      Libraries.logging.catsCore,
+      Libraries.logging.catsSlf4j,
+      Libraries.logging.logback
     )
-    .settings(
-      assembly / assemblyMergeStrategy := {
-        case PathList(ps @ _*) if ps.lastOption.contains("module-info.class") => MergeStrategy.discard
-        case x if x.endsWith(".conf")                                         => MergeStrategy.filterDistinctLines
-        case x if x.endsWith(".xml")                                          => MergeStrategy.filterDistinctLines
-        case x =>
-          val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
-          oldStrategy(x)
-      }
-    )
+  )
+  .settings(assembly / assemblyMergeStrategy := {
+    case PathList(ps @ _*) if ps.lastOption.contains("module-info.class") => MergeStrategy.discard
+    case x if x.endsWith(".conf") => MergeStrategy.filterDistinctLines
+    case x if x.endsWith(".xml") => MergeStrategy.filterDistinctLines
+    case x =>
+      val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
+      oldStrategy(x)
+  })
 
 lazy val commonSettings = commonScalacOptions ++ Seq(
   resolvers += "confluent" at "https://packages.confluent.io/maven/",
   update / evictionWarningOptions := EvictionWarningOptions.empty,
   assemblyMergeStrategy := {
     case PathList("META-INF") => MergeStrategy.discard
-    case x                    => MergeStrategy.first
+    case x => MergeStrategy.first
   }
 )
 
 lazy val commonScalacOptions = Seq(
-  Compile / console / scalacOptions --= Seq(
-    "-Wunused:_",
-    "-Xfatal-warnings"
-  ),
+  Compile / console / scalacOptions --= Seq("-Wunused:_", "-Xfatal-warnings"),
   Test / console / scalacOptions := (Compile / console / scalacOptions).value
 )

--- a/header.sbt
+++ b/header.sbt
@@ -1,3 +1,3 @@
 ThisBuild / organizationName := "Xebia Functional"
-ThisBuild / startYear        := Some(2023)
+ThisBuild / startYear := Some(2023)
 ThisBuild / licenses += ("Apache-2.0", java.net.URI.create("https://www.apache.org/licenses/LICENSE-2.0.txt").toURL)

--- a/project/CustomSbt.scala
+++ b/project/CustomSbt.scala
@@ -5,38 +5,27 @@ import sbt.*
 
 object CustomSbt {
 
-  def styled(in: Any): String =
-    scala.Console.CYAN + in + scala.Console.RESET
+  def styled(in: Any): String = scala.Console.CYAN + in + scala.Console.RESET
 
-  def prompt(projectName: String): String =
-    gitPrompt.fold(projectPrompt(projectName))(g => s"$g:${projectPrompt(projectName)}")
+  def prompt(projectName: String): String = gitPrompt
+    .fold(projectPrompt(projectName))(g => s"$g:${projectPrompt(projectName)}")
 
-  private def projectPrompt(projectName: String): String =
-    s"sbt:${styled(projectName)}"
+  private def projectPrompt(projectName: String): String = s"sbt:${styled(projectName)}"
 
-  def projectName(state: State): String =
-    Project.extract(state).currentRef.project
+  def projectName(state: State): String = Project.extract(state).currentRef.project
 
-  private def gitPrompt: Option[String] =
-    for {
-      b <- branch.map(styled)
-      h <- hash.map(styled)
-    } yield s"git:$b:$h"
+  private def gitPrompt: Option[String] = for {
+    b <- branch.map(styled)
+    h <- hash.map(styled)
+  } yield s"git:$b:$h"
 
-  private def branch: Option[String] =
-    run("git rev-parse --abbrev-ref HEAD")
+  private def branch: Option[String] = run("git rev-parse --abbrev-ref HEAD")
 
-  private def hash: Option[String] =
-    run("git rev-parse --short HEAD")
+  private def hash: Option[String] = run("git rev-parse --short HEAD")
 
-  private def run(command: String): Option[String] =
-    Try(
-      command.split(" ").toSeq.!!(noopProcessLogger).trim
-    ).toOption
+  private def run(command: String): Option[String] = Try(command.split(" ").toSeq.!!(noopProcessLogger).trim).toOption
 
-  private val noopProcessLogger: ProcessLogger =
-    ProcessLogger(_ => (), _ => ())
+  private val noopProcessLogger: ProcessLogger = ProcessLogger(_ => (), _ => ())
 
-  val Cctt: String =
-    "compile->compile;test->test"
+  val Cctt: String = "compile->compile;test->test"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,81 +5,83 @@ object Dependencies {
   object Libraries {
 
     object cats {
-      private val coreVersion: String   = "2.10.0"
+      private val coreVersion: String = "2.10.0"
       private val effectVersion: String = "3.5.2"
-      val core: ModuleID                = "org.typelevel" %% "cats-core"          % coreVersion
-      val effectKernel: ModuleID        = "org.typelevel" %% "cats-effect-kernel" % effectVersion
-      val effect: ModuleID              = "org.typelevel" %% "cats-effect"        % effectVersion
-      val free: ModuleID                = "org.typelevel" %% "cats-free"          % coreVersion
+      val core: ModuleID = "org.typelevel" %% "cats-core" % coreVersion
+      val effectKernel: ModuleID = "org.typelevel" %% "cats-effect-kernel" % effectVersion
+      val effect: ModuleID = "org.typelevel" %% "cats-effect" % effectVersion
+      val free: ModuleID = "org.typelevel" %% "cats-free" % coreVersion
     }
 
     object kafka {
-      private val clientVersion: String   = "7.5.0"
-      val kafkaClients: ModuleID          = "org.apache.kafka" % "kafka-clients"                % s"$clientVersion-ccs"
-      val kafkaSerializer: ModuleID       = "io.confluent"     % "kafka-avro-serializer"        % clientVersion
-      val kafkaSchemaRegistry: ModuleID   = "io.confluent"     % "kafka-schema-registry-client" % clientVersion
-      val kafkaSchemaSerializer: ModuleID = "io.confluent"     % "kafka-schema-serializer"      % clientVersion
+      private val clientVersion: String = "7.5.0"
+      val kafkaClients: ModuleID = "org.apache.kafka" % "kafka-clients" % s"$clientVersion-ccs"
+      val kafkaSerializer: ModuleID = "io.confluent" % "kafka-avro-serializer" % clientVersion
+      val kafkaSchemaRegistry: ModuleID = "io.confluent" % "kafka-schema-registry-client" % clientVersion
+      val kafkaSchemaSerializer: ModuleID = "io.confluent" % "kafka-schema-serializer" % clientVersion
     }
 
     object fs2 {
-      private val version: String      = "3.9.2"
+      private val version: String = "3.9.2"
       private val kafkaVersion: String = "3.1.0"
-      val core: ModuleID               = "co.fs2"          %% "fs2-core"         % version
-      val kafka: ModuleID              = "com.github.fd4s" %% "fs2-kafka"        % kafkaVersion
-      val kafkaVulcan: ModuleID        = "com.github.fd4s" %% "fs2-kafka-vulcan" % kafkaVersion
+      val core: ModuleID = "co.fs2" %% "fs2-core" % version
+      val kafka: ModuleID = "com.github.fd4s" %% "fs2-kafka" % kafkaVersion
+      val kafkaVulcan: ModuleID = "com.github.fd4s" %% "fs2-kafka-vulcan" % kafkaVersion
     }
 
     object avro {
-      val avro: ModuleID   = "org.apache.avro"  % "avro"   % "1.11.3"
+      val avro: ModuleID = "org.apache.avro" % "avro" % "1.11.3"
       val vulcan: ModuleID = "com.github.fd4s" %% "vulcan" % "1.9.0"
 
     }
 
     object config {
       private val pureConfigVersion: String = "0.17.4"
-      val ciris: ModuleID                   = "is.cir"                %% "ciris"                  % "3.2.0"
-      val pureConfig: ModuleID              = "com.github.pureconfig" %% "pureconfig-core"        % pureConfigVersion
-      val pureConfigCE: ModuleID            = "com.github.pureconfig" %% "pureconfig-cats-effect" % pureConfigVersion
+      val ciris: ModuleID = "is.cir" %% "ciris" % "3.2.0"
+      val pureConfig: ModuleID = "com.github.pureconfig" %% "pureconfig-core" % pureConfigVersion
+      val pureConfigCE: ModuleID = "com.github.pureconfig" %% "pureconfig-cats-effect" % pureConfigVersion
     }
 
     object flink {
       private val version: String = "1.17.1"
-      val avro: ModuleID          = "org.apache.flink" % "flink-avro"                    % version
+      val avro: ModuleID = "org.apache.flink" % "flink-avro" % version
       val avroConfluent: ModuleID = "org.apache.flink" % "flink-avro-confluent-registry" % version
-      val core: ModuleID          = "org.apache.flink" % "flink-core"                    % version
-      val clients: ModuleID       = "org.apache.flink" % "flink-clients"                 % version
-      val kafka: ModuleID         = "org.apache.flink" % "flink-connector-kafka"         % "3.0.0-1.17"
-      val streaming: ModuleID     = "org.apache.flink" % "flink-streaming-java"          % version
+      val core: ModuleID = "org.apache.flink" % "flink-core" % version
+      val clients: ModuleID = "org.apache.flink" % "flink-clients" % version
+      val kafka: ModuleID = "org.apache.flink" % "flink-connector-kafka" % "3.0.0-1.17"
+      val streaming: ModuleID = "org.apache.flink" % "flink-streaming-java" % version
     }
 
     object spark {
       private val version: String = "3.5.0"
-      val catalyst: ModuleID      = "org.apache.spark" %% "spark-catalyst"       % version % "provided"
-      val core: ModuleID          = "org.apache.spark" %% "spark-core"           % version % "provided"
-      val sql: ModuleID           = "org.apache.spark" %% "spark-sql"            % version % "provided"
-      val streaming: ModuleID     = "org.apache.spark" %% "spark-streaming"      % version % "provided"
-      val `sql-kafka`: ModuleID   = "org.apache.spark" %% "spark-sql-kafka-0-10" % version % "provided"
+      val catalyst: ModuleID = "org.apache.spark" %% "spark-catalyst" % version % "provided"
+      val core: ModuleID = "org.apache.spark" %% "spark-core" % version % "provided"
+      val sql: ModuleID = "org.apache.spark" %% "spark-sql" % version % "provided"
+      val streaming: ModuleID = "org.apache.spark" %% "spark-streaming" % version % "provided"
+      val `sql-kafka`: ModuleID = "org.apache.spark" %% "spark-sql-kafka-0-10" % version % "provided"
     }
 
     object testContainers {
       private val version: String = "0.40.14" // Dependency conflict on 0.40.15
-      val kafka: ModuleID         = "com.dimafeng" %% "testcontainers-scala-kafka" % version % Test
-      val munit: ModuleID         = "com.dimafeng" %% "testcontainers-scala-munit" % version % Test
+      val kafka: ModuleID = "com.dimafeng" %% "testcontainers-scala-kafka" % version % Test
+      val munit: ModuleID = "com.dimafeng" %% "testcontainers-scala-munit" % version % Test
     }
 
     object logging {
-      private val catsVersion: String    = "2.6.0"
+      private val catsVersion: String = "2.6.0"
       private val logbackVersion: String = "1.4.11"
-      val catsCore: ModuleID             = "org.typelevel" %% "log4cats-core"   % catsVersion
-      val catsSlf4j: ModuleID            = "org.typelevel" %% "log4cats-slf4j"  % catsVersion
-      val logback: ModuleID              = "ch.qos.logback" % "logback-classic" % logbackVersion // % Runtime
+      val catsCore: ModuleID = "org.typelevel" %% "log4cats-core" % catsVersion
+      val catsSlf4j: ModuleID = "org.typelevel" %% "log4cats-slf4j" % catsVersion
+      val logback: ModuleID = "ch.qos.logback" % "logback-classic" % logbackVersion // % Runtime
     }
 
     object test {
       private val munitScalacheckVersion: String = "1.0.4"
       private val munitCatsEffectVersion: String = "1.0.7"
-      val munitCatsEffect: ModuleID              = "org.typelevel" %% "munit-cats-effect-3"     % munitCatsEffectVersion % Test
-      val munitScalacheck: ModuleID              = "org.typelevel" %% "scalacheck-effect-munit" % munitScalacheckVersion % Test
+      val munitCatsEffect: ModuleID = "org.typelevel" %% "munit-cats-effect-3" % munitCatsEffectVersion % Test
+      val munitScalacheck: ModuleID = "org.typelevel" %% "scalacheck-effect-munit" % munitScalacheckVersion % Test
     }
+
   }
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,12 +4,12 @@ ThisBuild / autoStartServer := false
 
 addDependencyTreePlugin
 
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"              % "0.11.0")
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"              % "2.1.1")
-addSbtPlugin("com.github.cb372"  % "sbt-explicit-dependencies" % "0.3.1")
-addSbtPlugin("com.github.sbt"    % "sbt-git"                   % "2.0.1")
-addSbtPlugin("com.github.sbt"    % "sbt-native-packager"       % "1.9.16")
-addSbtPlugin("com.timushev.sbt"  % "sbt-updates"               % "0.6.3")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"                % "5.10.0")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"              % "2.5.0")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage"             % "2.0.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")

--- a/sbt.sbt
+++ b/sbt.sbt
@@ -2,28 +2,25 @@ import CustomSbt.*
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-Global / excludeLintKeys ++= Set(
-  autoStartServer,
-  turbo,
-  evictionWarningOptions
-)
+Global / excludeLintKeys ++= Set(autoStartServer, turbo, evictionWarningOptions)
 
 Test / parallelExecution := false
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oSD")
 Test / turbo := true
 
-ThisBuild / autoStartServer        := false
+ThisBuild / autoStartServer := false
 ThisBuild / includePluginResolvers := true
-ThisBuild / turbo                  := true
+ThisBuild / turbo := true
 
-ThisBuild / watchBeforeCommand           := Watch.clearScreen
-ThisBuild / watchTriggeredMessage        := Watch.clearScreenOnTrigger
+ThisBuild / watchBeforeCommand := Watch.clearScreen
+ThisBuild / watchTriggeredMessage := Watch.clearScreenOnTrigger
 ThisBuild / watchForceTriggerOnAnyChange := true
 
 ThisBuild / shellPrompt := { state => s"${prompt(projectName(state))}> " }
+
 ThisBuild / watchStartMessage := { case (iteration, ProjectRef(build, projectName), commands) =>
   Some {
     s"""|~${commands.map(styled).mkString(";")}
-          |Monitoring source files for ${prompt(projectName)}...""".stripMargin
+      |Monitoring source files for ${prompt(projectName)}...""".stripMargin
   }
 }


### PR DESCRIPTION
This is the new standard I am working on with some other colleagues at the client. 

Brief description of benefits:

- DisableSyntax:
  - noReturns: self explanatory
  - noXMl: self explanatory
  - noFinal: `final` keyword will be phased out in the future by the Scala team (see [here](https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html))
 
Other syntax can be problematic to forbid for now.

- OrganizeImports:
  - blankLines: adds empty line between groups
  - groups: first the functional stack that works as skeleton, then Scala or Java that is not available automatically. Then some Apache libraries. Finally the other libraries that are more characteristic and might give a specific flavor to the file.
  - removeUnused is still `false` because it cannot be used yet in Scala3
  - importsOrder/importsSelectorOrder = SymbolFirst to match the [deprecated default](https://scalameta.org/scalafmt/docs/configuration.html#imports-sort--original) of Scalafmt
  - expandRelative: very beneficial to avoid the new for fully qualified imports. An additional benefit is that it makes the diffs easier in the Pull-Requests by making it clear to see which imports have been deleted or added.
  
As for the scalafmt, there are some other settings, but the ones that I am focusing now are those that may reduces the diffs in PR. For example:
- newlines.selectChains = unfold: The computational chains (dot notation) are split into new lines. If the method does not take parameters, then nothing is gained. If the method takes parameters and any of this parameters is modified (let's say the name), then only one line diff in PR that is very specific. If the method takes a function, the function itself will be in a new line, so the diff is also clearer.

PS: there is a problem with this config, if inside the body of the function there are more method calls, these are not split into new lines unless some receives a function (it is rather about the curly braces).

- newlines.source = fold: this is the opposite of the previous and might seem counterintuitive. There is a trick. So... if a class, method, trait, etc. fits in 120 (`runner.optimizer.forceConfigStyleOnOffset = 120`) or has less than 4 parameters (`runner.optimizer.forceConfigStyleMinArgCount = 3`), then it will be folded. The brain can hold triads quite well. That means that we can fold 4 (or even 5 lines with the return type) into 1. Since this is usually the definition site, it works as a conceptual unit. Now, if it does not fit or it has more than 3 parameters, it is split into a multiline. Thus, gaining again all the benefits of clearer diffs in the PRs.

  